### PR TITLE
Fix panic when `sku` in one resource type is attribute and nested block in another resource type

### DIFF
--- a/pkg/data_resource_test.go
+++ b/pkg/data_resource_test.go
@@ -138,3 +138,39 @@ func TestResourceData_CustomizedToStringShouldContainsAllFields(t *testing.T) {
 	assert.Contains(t, sut, "use_for_each")
 	assert.Contains(t, sut, "result")
 }
+
+func TestResourceData_DifferentResourcesHaveAttributesWithSameNameButDifferentSchema(t *testing.T) {
+	stub := gostub.Stub(&filesystem.Fs, fakeFs(map[string]string{
+		"/main.tf": `resource "fake_resource" this {
+  sku = {
+    name = "Standard"
+  }  
+}
+
+resource "fake_resource2" this {
+  sku = 1
+}
+`,
+	}))
+	defer stub.Reset()
+	cfg, err := pkg.NewMetaProgrammingTFConfig(&pkg.TerraformModuleRef{
+		Dir:    "/",
+		AbsDir: "/",
+	}, nil, nil, nil, context.TODO())
+	require.NoError(t, err)
+
+	data := &pkg.ResourceData{
+		BaseBlock: golden.NewBaseBlock(cfg, nil),
+	}
+
+	err = data.ExecuteDuringPlan()
+	require.NoError(t, err)
+
+	var sut map[string]any
+	err = json.Unmarshal([]byte(data.String()), &sut)
+	require.NoError(t, err)
+	//assert.Contains(t, sut, "resource_type")
+	//assert.Contains(t, sut, "use_count")
+	//assert.Contains(t, sut, "use_for_each")
+	//assert.Contains(t, sut, "result")
+}

--- a/pkg/transform_update_in_place_test.go
+++ b/pkg/transform_update_in_place_test.go
@@ -232,7 +232,7 @@ transform update_in_place "fake_resource" {
 	err = cfg.RunPlan()
 	require.NoError(t, err)
 	vertices := cfg.BaseConfig.GetVertices()
-	b, ok := vertices["transform.update_in_place.fake_resource[resource.fake_resource.this]"]
+	b, ok := vertices["transform.update_in_place.fake_resource[this]"]
 	require.True(t, ok)
 	updateTransformBlock, ok := b.(*pkg.UpdateInPlaceTransform)
 	require.True(t, ok)
@@ -245,7 +245,7 @@ transform update_in_place "fake_resource" {
 })
 }`
 	assert.Equal(t, formatHcl(expected), formatHcl(actual))
-	b, ok = vertices["transform.update_in_place.fake_resource[resource.fake_resource.that]"]
+	b, ok = vertices["transform.update_in_place.fake_resource[that]"]
 	require.True(t, ok)
 	updateTransformBlock, ok = b.(*pkg.UpdateInPlaceTransform)
 	require.True(t, ok)


### PR DESCRIPTION
This pr changed how we store matched resource blocks in data source. Now we store these matched resource blocks as an huge object, each attribute is another object, the key is resource block's label[1] (name, eg: `this`).