### PR TITLE
Add `transform.ensure_local` block

### DIFF
--- a/pkg/init.go
+++ b/pkg/init.go
@@ -20,6 +20,7 @@ func registerTransform() {
 	golden.RegisterBlock(new(RenameAttributeOrNestedBlockTransform))
 	golden.RegisterBlock(new(RegexReplaceExpressionTransform))
 	golden.RegisterBlock(new(AppendBlockBodyTransform))
+	golden.RegisterBlock(new(EnsureLocalTransform))
 }
 
 func registerData() {

--- a/pkg/transform_ensure_local.go
+++ b/pkg/transform_ensure_local.go
@@ -1,0 +1,77 @@
+package pkg
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/Azure/golden"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+var _ Transform = &EnsureLocalTransform{}
+var _ golden.CustomDecode = &EnsureLocalTransform{}
+
+type EnsureLocalTransform struct {
+	*golden.BaseBlock
+	*BaseTransform
+	LocalName        string `hcl:"name" validate:"required"`
+	FallbackFileName string `hcl:"fallback_file_name" validate:"required"`
+	writeBlock       *hclwrite.Block
+	tokens           hclwrite.Tokens
+}
+
+func (u *EnsureLocalTransform) Type() string {
+	return "ensure_local"
+}
+
+func (u *EnsureLocalTransform) Apply() error {
+	u.writeBlock.Body().SetAttributeRaw(u.LocalName, u.tokens)
+	return nil
+}
+
+func (u *EnsureLocalTransform) Decode(block *golden.HclBlock, context *hcl.EvalContext) error {
+	var err error
+	u.LocalName, err = getRequiredStringAttribute("name", block, context)
+	if err != nil {
+		return err
+	}
+	u.FallbackFileName, err = getRequiredStringAttribute("fallback_file_name", block, context)
+	if err != nil {
+		return err
+	}
+	cfg := u.Config().(*MetaProgrammingTFConfig)
+	b, ok := cfg.localBlocks[fmt.Sprintf("local.%s", u.LocalName)]
+	if ok {
+		u.writeBlock = b.WriteBlock
+	}
+	asString, err := getOptionalStringAttribute("value_as_string", block, context)
+	if err != nil {
+		return err
+	}
+	raw, asRaw := block.Attributes()["value_as_raw"]
+	if asString != nil && asRaw {
+		return fmt.Errorf("cannot use both value_as_string and value_as_raw")
+	}
+	if asString != nil {
+		u.tokens, err = stringToHclWriteTokens(*asString)
+		if err != nil {
+			return err
+		}
+	}
+	if asRaw {
+		u.tokens = raw.ExprTokens()
+	}
+	return nil
+}
+
+func (u *EnsureLocalTransform) String() string {
+	content := make(map[string]any)
+	content["id"] = u.Id()
+	content["name"] = u.LocalName
+	content["value"] = string(u.tokens.Bytes())
+	str, err := json.Marshal(content)
+	if err != nil {
+		panic(err.Error())
+	}
+	return string(str)
+}

--- a/pkg/transform_ensure_local_test.go
+++ b/pkg/transform_ensure_local_test.go
@@ -1,0 +1,76 @@
+package pkg_test
+
+import (
+	"context"
+	"github.com/Azure/mapotf/pkg"
+	"testing"
+
+	filesystem "github.com/Azure/mapotf/pkg/fs"
+	"github.com/prashantv/gostub"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransformEnsureLocal(t *testing.T) {
+	cases := []struct {
+		desc       string
+		mptfConfig string
+		tfConfig   string
+		expectedTf string
+	}{
+		{
+			desc: "replace value astring",
+			mptfConfig: `transform "ensure_local" this{
+	name = "this"
+    fallback_file_name = "main.tf"
+	value_as_string = "local.that"
+}`,
+			tfConfig: `locals {
+	this = "hello"
+}`,
+			expectedTf: `locals {
+	this = local.that
+}`,
+		},
+		{
+			desc: "replace value asraw",
+			mptfConfig: `transform "ensure_local" this{
+	name = "this"
+    fallback_file_name = "main.tf"
+	value_as_raw = local.that
+}`,
+			tfConfig: `locals {
+	this = "hello"
+}`,
+			expectedTf: `locals {
+	this = local.that
+}`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			mockFs := fakeFs(map[string]string{
+				"/main.tf":       c.tfConfig,
+				"/main.mptf.hcl": c.mptfConfig,
+			})
+			stub := gostub.Stub(&filesystem.Fs, mockFs)
+			defer stub.Reset()
+
+			hclBlocks, err := pkg.LoadMPTFHclBlocks(false, "/")
+			require.NoError(t, err)
+			cfg, err := pkg.NewMetaProgrammingTFConfig(&pkg.TerraformModuleRef{
+				Dir:    "/",
+				AbsDir: "/",
+			}, nil, hclBlocks, nil, context.TODO())
+			require.NoError(t, err)
+			plan, err := pkg.RunMetaProgrammingTFPlan(cfg)
+			require.NoError(t, err)
+			require.NoError(t, plan.Apply())
+
+			file, err := afero.ReadFile(mockFs, "/main.tf")
+			require.NoError(t, err)
+			assert.Equal(t, formatHcl(c.expectedTf), formatHcl(string(file)))
+		})
+	}
+}


### PR DESCRIPTION
`local` expression be used with `transform.update_in_place` block is very cumbersome and error prone. This pr added `transform_ensure_local` block, if you'd like to set expression for a `local` expression, just provide a name, the expression, a filename if we have to create a new `locals` block.