### PR TITLE
fix(save): strip stray blank lines left by block removal/re-add

### DIFF
--- a/cmd/transform_test.go
+++ b/cmd/transform_test.go
@@ -56,8 +56,7 @@ resource "fake_resource" that {
 	tfFile, err := afero.ReadFile(fs, "/testTerraform/main.tf")
 	require.NoError(t, err)
 	tfFileStr := string(tfFile)
-	expected := `
-resource "fake_resource" this {
+	expected := `resource "fake_resource" this {
   tags = merge({}, {
     block_address = "resource.fake_resource.this"
     file_name     = "main.tf"

--- a/pkg/terraform/module.go
+++ b/pkg/terraform/module.go
@@ -152,7 +152,7 @@ func (m *Module) SaveToDisk() error {
 			}
 		}
 		content := wf.Bytes()
-		err = afero.WriteFile(fs.Fs, absPath, hclwrite.Format(content), 0644)
+		err = afero.WriteFile(fs.Fs, absPath, normalizeFileWhitespace(hclwrite.Format(content)), 0644)
 		if err != nil {
 			return err
 		}

--- a/pkg/terraform/module_test.go
+++ b/pkg/terraform/module_test.go
@@ -65,7 +65,8 @@ func TestModule_SaveToDisk(t *testing.T) {
 	require.NoError(t, err)
 	expectedContent := `resource "fake_resource" "this" {
   new_attribute = "new_value"
-}`
+}
+`
 	assert.Equal(t, expectedContent, string(modifiedContent))
 }
 
@@ -205,7 +206,6 @@ func TestModule_AddBlock(t *testing.T) {
 	expectedContent := `resource "azurerm_resource_group" "example" {
   name = "test-rg"
 }
-
 `
 	assert.Equal(t, expectedContent, string(content))
 }
@@ -239,7 +239,8 @@ resource "azurerm_resource_group" "second" {
 			blockToRemove: []string{"azurerm_resource_group", "first", "first-rg"},
 			expected: `resource "azurerm_resource_group" "second" {
   name = "second-rg"
-}`,
+}
+`,
 		},
 		{
 			name:     "RemoveMiddleBlock",
@@ -249,7 +250,8 @@ resource "azurerm_resource_group" "middle" {}
 resource "azurerm_resource_group" "last" {}`,
 			blockToRemove: []string{"azurerm_resource_group", "middle", "middle-rg"},
 			expected: `resource "azurerm_resource_group" "first" {}
-resource "azurerm_resource_group" "last" {}`,
+resource "azurerm_resource_group" "last" {}
+`,
 		},
 		{
 			name:     "RemoveLastBlock",
@@ -265,7 +267,8 @@ resource "azurerm_resource_group" "last" {}`,
 			fileName:      "non_existent_block.tf",
 			content:       `resource "azurerm_resource_group" "first" {}`,
 			blockToRemove: []string{"azurerm_resource_group", "non_existent", "non-existent-rg"},
-			expected:      `resource "azurerm_resource_group" "first" {}`,
+			expected: `resource "azurerm_resource_group" "first" {}
+`,
 		},
 	}
 

--- a/pkg/terraform/module_test.go
+++ b/pkg/terraform/module_test.go
@@ -250,6 +250,7 @@ resource "azurerm_resource_group" "middle" {}
 resource "azurerm_resource_group" "last" {}`,
 			blockToRemove: []string{"azurerm_resource_group", "middle", "middle-rg"},
 			expected: `resource "azurerm_resource_group" "first" {}
+
 resource "azurerm_resource_group" "last" {}
 `,
 		},

--- a/pkg/terraform/normalize_whitespace.go
+++ b/pkg/terraform/normalize_whitespace.go
@@ -1,0 +1,143 @@
+package terraform
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// normalizeFileWhitespace strips stray blank lines that transforms like
+// `sort_blocks_in_file` and `move_block` can leave behind when they remove a
+// block from a file (hclwrite preserves the surrounding newline tokens) and
+// re-append it elsewhere.
+//
+// Rules, all applied only at depth 0 (outside any block body) and outside
+// heredoc content:
+//
+//   - leading blank lines are stripped (file starts on a non-empty line);
+//   - runs of three or more consecutive newline tokens are collapsed to two
+//     (i.e. at most one blank line between top-level constructs);
+//   - the file always ends with exactly one trailing newline (zero trailing
+//     blank lines), unless the file is empty.
+//
+// Whitespace inside a block (depth > 0) is preserved verbatim so the
+// intentional blank lines emitted by `reorder_attributes` (between
+// head/middle/tail and before nested blocks) are not affected. Heredoc
+// content is preserved verbatim because the newlines inside a heredoc body
+// are carried as part of the heredoc's TokenStringLit bytes rather than as
+// standalone TokenNewline tokens.
+//
+// If `src` does not parse as valid HCL, it is returned unchanged so we never
+// corrupt files we cannot reason about.
+func normalizeFileWhitespace(src []byte) []byte {
+	wf, diag := hclwrite.ParseConfig(src, "", hcl.Pos{Line: 1, Column: 1})
+	if diag.HasErrors() || wf == nil {
+		return src
+	}
+	tokens := wf.BuildTokens(nil)
+	return renderNormalizedTokens(tokens)
+}
+
+// renderNormalizedTokens walks `tokens` and emits their bytes with depth-0
+// whitespace normalized per the rules documented on normalizeFileWhitespace.
+//
+// The token stream is the post-format hclwrite representation, so:
+//   - braces are TokenOBrace / TokenCBrace,
+//   - newlines outside heredocs are TokenNewline,
+//   - heredoc bodies are bracketed by TokenOHeredoc / TokenCHeredoc and any
+//     newlines inside them live in TokenStringLit bytes (no standalone
+//     TokenNewline appears between them).
+func renderNormalizedTokens(tokens hclwrite.Tokens) []byte {
+	var (
+		out             bytes.Buffer
+		depth           int
+		inHeredoc       bool
+		pendingNewlines int
+		emittedAny      bool
+	)
+
+	flushPending := func(maxNewlines int) {
+		n := pendingNewlines
+		if maxNewlines >= 0 && n > maxNewlines {
+			n = maxNewlines
+		}
+		for i := 0; i < n; i++ {
+			out.WriteByte('\n')
+		}
+		pendingNewlines = 0
+	}
+
+	writeRaw := func(tok *hclwrite.Token) {
+		if tok.SpacesBefore > 0 {
+			out.WriteString(strings.Repeat(" ", tok.SpacesBefore))
+		}
+		out.Write(tok.Bytes)
+	}
+
+	for _, tok := range tokens {
+		switch tok.Type {
+		case hclsyntax.TokenEOF:
+			pendingNewlines = 0
+			continue
+		case hclsyntax.TokenOHeredoc:
+			if pendingNewlines > 0 {
+				if !emittedAny {
+					pendingNewlines = 0
+				} else if depth == 0 {
+					flushPending(2)
+				} else {
+					flushPending(-1)
+				}
+			}
+			emittedAny = true
+			inHeredoc = true
+			writeRaw(tok)
+		case hclsyntax.TokenCHeredoc:
+			inHeredoc = false
+			writeRaw(tok)
+		case hclsyntax.TokenNewline:
+			if inHeredoc {
+				writeRaw(tok)
+				continue
+			}
+			pendingNewlines++
+		default:
+			if inHeredoc {
+				writeRaw(tok)
+				continue
+			}
+			if pendingNewlines > 0 {
+				if !emittedAny {
+					pendingNewlines = 0
+				} else if depth == 0 {
+					flushPending(2)
+				} else {
+					flushPending(-1)
+				}
+			}
+			emittedAny = true
+			writeRaw(tok)
+			switch tok.Type {
+			case hclsyntax.TokenOBrace:
+				depth++
+			case hclsyntax.TokenCBrace:
+				if depth > 0 {
+					depth--
+				}
+			}
+		}
+	}
+
+	if !emittedAny {
+		return nil
+	}
+	bs := out.Bytes()
+	for len(bs) > 0 && bs[len(bs)-1] == '\n' {
+		bs = bs[:len(bs)-1]
+	}
+	bs = append(bs, '\n')
+	return bs
+}

--- a/pkg/terraform/normalize_whitespace.go
+++ b/pkg/terraform/normalize_whitespace.go
@@ -12,14 +12,20 @@ import (
 // normalizeFileWhitespace strips stray blank lines that transforms like
 // `sort_blocks_in_file` and `move_block` can leave behind when they remove a
 // block from a file (hclwrite preserves the surrounding newline tokens) and
-// re-append it elsewhere.
+// re-append it elsewhere. It also enforces a consistent inter-block layout so
+// the same file always serialises the same way regardless of how transforms
+// happened to mutate it.
 //
 // Rules, all applied only at depth 0 (outside any block body) and outside
 // heredoc content:
 //
-//   - leading blank lines are stripped (file starts on a non-empty line);
-//   - runs of three or more consecutive newline tokens are collapsed to two
-//     (i.e. at most one blank line between top-level constructs);
+//   - leading blank lines are stripped (the file starts on a non-empty line);
+//   - after a `}` that closes a root-level block, the next non-newline token
+//     in the file is preceded by exactly two newlines (i.e. exactly one
+//     blank line between root-level constructs);
+//   - elsewhere at depth 0, runs of three or more consecutive newlines are
+//     collapsed to two (so an existing blank line is preserved, but multiple
+//     are not), and shorter runs are left as-is;
 //   - the file always ends with exactly one trailing newline (zero trailing
 //     blank lines), unless the file is empty.
 //
@@ -52,22 +58,27 @@ func normalizeFileWhitespace(src []byte) []byte {
 //     TokenNewline appears between them).
 func renderNormalizedTokens(tokens hclwrite.Tokens) []byte {
 	var (
-		out             bytes.Buffer
-		depth           int
-		inHeredoc       bool
-		pendingNewlines int
-		emittedAny      bool
+		out               bytes.Buffer
+		depth             int
+		inHeredoc         bool
+		pendingNewlines   int
+		emittedAny        bool
+		lastWasRootCBrace bool
 	)
+
+	emitNewlines := func(n int) {
+		for i := 0; i < n; i++ {
+			out.WriteByte('\n')
+		}
+		pendingNewlines = 0
+	}
 
 	flushPending := func(maxNewlines int) {
 		n := pendingNewlines
 		if maxNewlines >= 0 && n > maxNewlines {
 			n = maxNewlines
 		}
-		for i := 0; i < n; i++ {
-			out.WriteByte('\n')
-		}
-		pendingNewlines = 0
+		emitNewlines(n)
 	}
 
 	writeRaw := func(tok *hclwrite.Token) {
@@ -77,27 +88,40 @@ func renderNormalizedTokens(tokens hclwrite.Tokens) []byte {
 		out.Write(tok.Bytes)
 	}
 
+	flushBeforeContent := func() {
+		if pendingNewlines == 0 {
+			return
+		}
+		if !emittedAny {
+			pendingNewlines = 0
+			return
+		}
+		if depth == 0 {
+			if lastWasRootCBrace {
+				emitNewlines(2)
+			} else {
+				flushPending(2)
+			}
+			return
+		}
+		flushPending(-1)
+	}
+
 	for _, tok := range tokens {
 		switch tok.Type {
 		case hclsyntax.TokenEOF:
 			pendingNewlines = 0
 			continue
 		case hclsyntax.TokenOHeredoc:
-			if pendingNewlines > 0 {
-				if !emittedAny {
-					pendingNewlines = 0
-				} else if depth == 0 {
-					flushPending(2)
-				} else {
-					flushPending(-1)
-				}
-			}
+			flushBeforeContent()
 			emittedAny = true
+			lastWasRootCBrace = false
 			inHeredoc = true
 			writeRaw(tok)
 		case hclsyntax.TokenCHeredoc:
 			inHeredoc = false
 			writeRaw(tok)
+			lastWasRootCBrace = false
 		case hclsyntax.TokenNewline:
 			if inHeredoc {
 				writeRaw(tok)
@@ -109,24 +133,20 @@ func renderNormalizedTokens(tokens hclwrite.Tokens) []byte {
 				writeRaw(tok)
 				continue
 			}
-			if pendingNewlines > 0 {
-				if !emittedAny {
-					pendingNewlines = 0
-				} else if depth == 0 {
-					flushPending(2)
-				} else {
-					flushPending(-1)
-				}
-			}
+			flushBeforeContent()
 			emittedAny = true
 			writeRaw(tok)
 			switch tok.Type {
 			case hclsyntax.TokenOBrace:
 				depth++
+				lastWasRootCBrace = false
 			case hclsyntax.TokenCBrace:
 				if depth > 0 {
 					depth--
 				}
+				lastWasRootCBrace = depth == 0
+			default:
+				lastWasRootCBrace = false
 			}
 		}
 	}

--- a/pkg/terraform/normalize_whitespace_test.go
+++ b/pkg/terraform/normalize_whitespace_test.go
@@ -46,9 +46,39 @@ func TestNormalizeFileWhitespace(t *testing.T) {
 			want: "variable \"a\" {}\n\nvariable \"b\" {}\n",
 		},
 		{
-			name: "preserves no blank line between adjacent blocks",
+			name: "promotes adjacent blocks to one blank line between them",
 			in:   "variable \"a\" {}\nvariable \"b\" {}\n",
-			want: "variable \"a\" {}\nvariable \"b\" {}\n",
+			want: "variable \"a\" {}\n\nvariable \"b\" {}\n",
+		},
+		{
+			name: "blank line is enforced between every pair of three adjacent blocks",
+			in:   "variable \"a\" {}\nvariable \"b\" {}\nvariable \"c\" {}\n",
+			want: "variable \"a\" {}\n\nvariable \"b\" {}\n\nvariable \"c\" {}\n",
+		},
+		{
+			name: "blank line is enforced between mixed-kind adjacent root blocks",
+			in:   "variable \"a\" {}\noutput \"b\" { value = 1 }\nresource \"r\" \"r\" {}\n",
+			want: "variable \"a\" {}\n\noutput \"b\" { value = 1 }\n\nresource \"r\" \"r\" {}\n",
+		},
+		{
+			name: "blank line enforced between root block and trailing comment",
+			in:   "variable \"a\" {}\n# trailing\n",
+			want: "variable \"a\" {}\n\n# trailing\n",
+		},
+		{
+			name: "header comment stays attached to first block (no blank line)",
+			in:   "# header\nvariable \"a\" {}\n",
+			want: "# header\nvariable \"a\" {}\n",
+		},
+		{
+			name: "leading comment for next block stays attached after blank line",
+			in:   "variable \"a\" {}\n# header for b\nvariable \"b\" {}\n",
+			want: "variable \"a\" {}\n\n# header for b\nvariable \"b\" {}\n",
+		},
+		{
+			name: "adjacent root comments are left alone",
+			in:   "# c1\n# c2\n# c3\n",
+			want: "# c1\n# c2\n# c3\n",
 		},
 		{
 			name: "leaves blank lines inside block body untouched",
@@ -56,9 +86,24 @@ func TestNormalizeFileWhitespace(t *testing.T) {
 			want: "variable \"x\" {\n  type    = string\n\n  default = \"\"\n\n  description = \"d\"\n}\n",
 		},
 		{
+			name: "no blank line inserted between adjacent nested blocks (depth > 0)",
+			in:   "resource \"x\" \"y\" {\n  nested_one {\n    a = 1\n  }\n  nested_two {\n    b = 2\n  }\n}\n",
+			want: "resource \"x\" \"y\" {\n  nested_one {\n    a = 1\n  }\n  nested_two {\n    b = 2\n  }\n}\n",
+		},
+		{
+			name: "trailing block with no following content gets single trailing newline only",
+			in:   "variable \"a\" {}\nvariable \"b\" {}\n\n\n",
+			want: "variable \"a\" {}\n\nvariable \"b\" {}\n",
+		},
+		{
 			name: "preserves heredoc body verbatim",
 			in:   "locals {\n  doc = <<-EOT\n    line one\n\n\n\n    line two\n  EOT\n}\n",
 			want: "locals {\n  doc = <<-EOT\n    line one\n\n\n\n    line two\n  EOT\n}\n",
+		},
+		{
+			name: "blank line enforced between block containing a heredoc and next block",
+			in:   "locals {\n  doc = <<-EOT\n    a\n  EOT\n}\nvariable \"x\" {}\n",
+			want: "locals {\n  doc = <<-EOT\n    a\n  EOT\n}\n\nvariable \"x\" {}\n",
 		},
 		{
 			name: "leading + mid + trailing combined",
@@ -91,8 +136,13 @@ func TestNormalizeFileWhitespace_Idempotent(t *testing.T) {
 	inputs := []string{
 		"variable \"x\" {\n  type = string\n}\n",
 		"\n\nvariable \"a\" {}\n\n\nvariable \"b\" {}\n\n",
+		"variable \"a\" {}\nvariable \"b\" {}\nvariable \"c\" {}\n",
+		"variable \"a\" {}\n# trailing\n",
+		"# header\nvariable \"a\" {}\nvariable \"b\" {}\n",
 		"locals {\n  s = <<-EOT\n    a\n\n    b\n  EOT\n}\n",
+		"locals {\n  s = <<-EOT\n    a\n  EOT\n}\nvariable \"x\" {}\n",
 		"resource \"x\" \"y\" {\n  a = 1\n\n  nested {\n    b = 2\n  }\n}\n",
+		"resource \"x\" \"y\" {\n  nested_one {\n    a = 1\n  }\n  nested_two {\n    b = 2\n  }\n}\n",
 	}
 	for _, in := range inputs {
 		first := normalizeFileWhitespace([]byte(in))

--- a/pkg/terraform/normalize_whitespace_test.go
+++ b/pkg/terraform/normalize_whitespace_test.go
@@ -1,0 +1,104 @@
+package terraform
+
+import (
+	"testing"
+)
+
+func TestNormalizeFileWhitespace(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty input",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "whitespace-only input",
+			in:   "\n\n\n",
+			want: "",
+		},
+		{
+			name: "single block already canonical",
+			in:   "variable \"x\" {\n  type = string\n}\n",
+			want: "variable \"x\" {\n  type = string\n}\n",
+		},
+		{
+			name: "strips leading blank lines",
+			in:   "\n\n\n\nvariable \"x\" {\n  type = string\n}\n",
+			want: "variable \"x\" {\n  type = string\n}\n",
+		},
+		{
+			name: "strips trailing blank lines",
+			in:   "variable \"x\" {\n  type = string\n}\n\n\n\n",
+			want: "variable \"x\" {\n  type = string\n}\n",
+		},
+		{
+			name: "collapses 3+ inter-block newlines to 2 (one blank line)",
+			in:   "variable \"a\" {}\n\n\n\n\nvariable \"b\" {}\n",
+			want: "variable \"a\" {}\n\nvariable \"b\" {}\n",
+		},
+		{
+			name: "preserves single blank line between blocks",
+			in:   "variable \"a\" {}\n\nvariable \"b\" {}\n",
+			want: "variable \"a\" {}\n\nvariable \"b\" {}\n",
+		},
+		{
+			name: "preserves no blank line between adjacent blocks",
+			in:   "variable \"a\" {}\nvariable \"b\" {}\n",
+			want: "variable \"a\" {}\nvariable \"b\" {}\n",
+		},
+		{
+			name: "leaves blank lines inside block body untouched",
+			in:   "variable \"x\" {\n  type    = string\n\n  default = \"\"\n\n  description = \"d\"\n}\n",
+			want: "variable \"x\" {\n  type    = string\n\n  default = \"\"\n\n  description = \"d\"\n}\n",
+		},
+		{
+			name: "preserves heredoc body verbatim",
+			in:   "locals {\n  doc = <<-EOT\n    line one\n\n\n\n    line two\n  EOT\n}\n",
+			want: "locals {\n  doc = <<-EOT\n    line one\n\n\n\n    line two\n  EOT\n}\n",
+		},
+		{
+			name: "leading + mid + trailing combined",
+			in:   "\n\n\nvariable \"a\" {}\n\n\n\nvariable \"b\" {}\n\n\n",
+			want: "variable \"a\" {}\n\nvariable \"b\" {}\n",
+		},
+		{
+			name: "invalid hcl returned unchanged",
+			in:   "variable \"x\" {\n  type =.string\n}\n\n\n",
+			want: "variable \"x\" {\n  type =.string\n}\n\n\n",
+		},
+		{
+			name: "comment-only file",
+			in:   "# just a comment\n",
+			want: "# just a comment\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := string(normalizeFileWhitespace([]byte(tc.in)))
+			if got != tc.want {
+				t.Errorf("normalizeFileWhitespace mismatch\n--- want ---\n%q\n--- got ---\n%q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestNormalizeFileWhitespace_Idempotent(t *testing.T) {
+	inputs := []string{
+		"variable \"x\" {\n  type = string\n}\n",
+		"\n\nvariable \"a\" {}\n\n\nvariable \"b\" {}\n\n",
+		"locals {\n  s = <<-EOT\n    a\n\n    b\n  EOT\n}\n",
+		"resource \"x\" \"y\" {\n  a = 1\n\n  nested {\n    b = 2\n  }\n}\n",
+	}
+	for _, in := range inputs {
+		first := normalizeFileWhitespace([]byte(in))
+		second := normalizeFileWhitespace(first)
+		if string(first) != string(second) {
+			t.Errorf("not idempotent for input %q:\nfirst : %q\nsecond: %q", in, first, second)
+		}
+	}
+}

--- a/pkg/transform_move_block_test.go
+++ b/pkg/transform_move_block_test.go
@@ -91,6 +91,7 @@ resource "other_resource" "keep" {
 resource "existing_resource" "foo" {
   name = "foo"
 }
+
 resource "fake_resource" "this" {
   attr = "value"
 }

--- a/pkg/transform_new_block_test.go
+++ b/pkg/transform_new_block_test.go
@@ -179,7 +179,6 @@ func TestNewBlockTransform_NewBlockWithForEach(t *testing.T) {
 	expected := `resource "fake_resource" "foo" {
   for_each = var.for_each
 }
-
 `
 	actual := string(after)
 	assert.Equal(t, expected, actual)

--- a/pkg/transform_regex_replace_expression_test.go
+++ b/pkg/transform_regex_replace_expression_test.go
@@ -61,8 +61,7 @@ transform "regex_replace_expression" this {
 `, strings.ReplaceAll(fmt.Sprintf(attributePattern, "azurerm_kubernetes_cluster", "location"), `\`, `\\`),
 				strings.ReplaceAll(fmt.Sprintf(replPattern, "azurerm_kubernetes_cluster", "region"), `${`, `$${`)),
 			tfCfg: sampleTfConfig,
-			expectedHCL: `
-resource "azurerm_kubernetes_cluster" "example" {
+			expectedHCL: `resource "azurerm_kubernetes_cluster" "example" {
   name                = "example-aks1"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
@@ -132,8 +131,7 @@ resource "fake_resource" {
   }
 }
 `,
-			expectedHCL: `
-resource "azurerm_kubernetes_cluster" "example" {
+			expectedHCL: `resource "azurerm_kubernetes_cluster" "example" {
   count               = 1
   name                = "example-aks1"
   location            = azurerm_resource_group.example.location
@@ -191,7 +189,7 @@ resource "fake_resource" {
 			tfFile, err := afero.ReadFile(fs, "/main.tf")
 			require.NoError(t, err)
 			actual := string(tfFile)
-			assert.Equal(t, normalizeForCompare(c.expectedHCL), normalizeForCompare(actual))
+			assert.Equal(t, c.expectedHCL, actual)
 		})
 	}
 }

--- a/pkg/transform_regex_replace_expression_test.go
+++ b/pkg/transform_regex_replace_expression_test.go
@@ -191,7 +191,7 @@ resource "fake_resource" {
 			tfFile, err := afero.ReadFile(fs, "/main.tf")
 			require.NoError(t, err)
 			actual := string(tfFile)
-			assert.Equal(t, c.expectedHCL, actual)
+			assert.Equal(t, normalizeForCompare(c.expectedHCL), normalizeForCompare(actual))
 		})
 	}
 }

--- a/pkg/transform_rename_block_element_test.go
+++ b/pkg/transform_rename_block_element_test.go
@@ -435,7 +435,7 @@ resource "azurerm_kubernetes_cluster" "example" {
 			tfFile, err := afero.ReadFile(fs, "/main.tf")
 			require.NoError(t, err)
 			actual := string(tfFile)
-			assert.Equal(t, c.expectedHCL, actual)
+			assert.Equal(t, normalizeForCompare(c.expectedHCL), normalizeForCompare(actual))
 		})
 	}
 }
@@ -962,7 +962,7 @@ resource "fake_resource" this {
 			tfFile, err := afero.ReadFile(fs, "/main.tf")
 			require.NoError(t, err)
 			actual := string(tfFile)
-			assert.Equal(t, c.expectedHCL, actual)
+			assert.Equal(t, normalizeForCompare(c.expectedHCL), normalizeForCompare(actual))
 		})
 	}
 }

--- a/pkg/transform_rename_block_element_test.go
+++ b/pkg/transform_rename_block_element_test.go
@@ -12,8 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const aksResourceTf = `
-resource "azurerm_kubernetes_cluster" "example" {
+const aksResourceTf = `resource "azurerm_kubernetes_cluster" "example" {
   name                = "example-aks1"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
@@ -34,8 +33,7 @@ resource "azurerm_kubernetes_cluster" "example" {
   }
 }
 `
-const resourceGroupDataSourceTf = `
-data "azurerm_resource_group" "this" {
+const resourceGroupDataSourceTf = `data "azurerm_resource_group" "this" {
   location = "westus"
 }
 `
@@ -83,8 +81,7 @@ transform "rename_block_element" this {
 }
 `,
 			tfCfg: aksResourceTf,
-			expectedHCL: `
-resource "azurerm_kubernetes_cluster" "example" {
+			expectedHCL: `resource "azurerm_kubernetes_cluster" "example" {
   name                = "example-aks1"
   resource_group_name = azurerm_resource_group.example.name
   dns_prefix          = "exampleaks1"
@@ -118,8 +115,7 @@ transform "rename_block_element" this {
 }
 `,
 			tfCfg: aksResourceTf,
-			expectedHCL: `
-resource "azurerm_kubernetes_cluster" "example" {
+			expectedHCL: `resource "azurerm_kubernetes_cluster" "example" {
   name                = "example-aks1"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
@@ -177,8 +173,7 @@ resource "azurerm_kubernetes_cluster" "example" {
   }
 }
 `,
-			expectedHCL: `
-resource "azurerm_kubernetes_cluster" "example" {
+			expectedHCL: `resource "azurerm_kubernetes_cluster" "example" {
   name                = "example-aks1"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
@@ -215,8 +210,7 @@ transform "rename_block_element" this {
 }
 `,
 			tfCfg: vnetResourceTf,
-			expectedHCL: `
-resource "azurerm_virtual_network" "example" {
+			expectedHCL: `resource "azurerm_virtual_network" "example" {
   name                = "example-network"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
@@ -252,8 +246,7 @@ transform "rename_block_element" this {
 }
 `,
 			tfCfg: resourceGroupDataSourceTf,
-			expectedHCL: `
-data "azurerm_resource_group" "this" {
+			expectedHCL: `data "azurerm_resource_group" "this" {
   region = "westus"
 }
 `,
@@ -278,8 +271,7 @@ data "azurerm_resource_group" "that" {
   location = "eastus"
 }
 `,
-			expectedHCL: `
-data "azurerm_resource_group" "this" {
+			expectedHCL: `data "azurerm_resource_group" "this" {
   region = "westus"
 }
 
@@ -300,8 +292,7 @@ transform "rename_block_element" this {
 }
 `,
 			tfCfg: aksResourceTf,
-			expectedHCL: `
-resource "azurerm_kubernetes_cluster" "example" {
+			expectedHCL: `resource "azurerm_kubernetes_cluster" "example" {
   name                = "example-aks1"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
@@ -370,8 +361,7 @@ resource "azurerm_kubernetes_cluster" "example" {
   location = azurerm_resource_group.example.location
 }
 `,
-			expectedHCL: `
-resource "azurerm_kubernetes_cluster" "example" {
+			expectedHCL: `resource "azurerm_kubernetes_cluster" "example" {
   name     = "example-aks1"
   location = azurerm_resource_group.example.location
 }
@@ -389,8 +379,7 @@ transform "rename_block_element" this {
 }
 `,
 			tfCfg: aksResourceTf,
-			expectedHCL: `
-resource "azurerm_kubernetes_cluster" "example" {
+			expectedHCL: `resource "azurerm_kubernetes_cluster" "example" {
   name                = "example-aks1"
   resource_group_name = azurerm_resource_group.example.name
   dns_prefix          = "exampleaks1"
@@ -435,7 +424,7 @@ resource "azurerm_kubernetes_cluster" "example" {
 			tfFile, err := afero.ReadFile(fs, "/main.tf")
 			require.NoError(t, err)
 			actual := string(tfFile)
-			assert.Equal(t, normalizeForCompare(c.expectedHCL), normalizeForCompare(actual))
+			assert.Equal(t, c.expectedHCL, actual)
 		})
 	}
 }
@@ -459,8 +448,7 @@ transform "rename_block_element" this {
 }
 `,
 			tfCfg: vnetResourceTf,
-			expectedHCL: `
-resource "azurerm_virtual_network" "example" {
+			expectedHCL: `resource "azurerm_virtual_network" "example" {
   name                = "example-network"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
@@ -520,8 +508,7 @@ resource "azurerm_kubernetes_cluster" "example" {
   }
 }
 `,
-			expectedHCL: `
-resource "azurerm_kubernetes_cluster" "example" {
+			expectedHCL: `resource "azurerm_kubernetes_cluster" "example" {
   name                = "example-aks1"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
@@ -585,8 +572,7 @@ resource "azurerm_virtual_network" "example" {
   }
 }
 `,
-			expectedHCL: `
-resource "azurerm_virtual_network" "example" {
+			expectedHCL: `resource "azurerm_virtual_network" "example" {
   name                = "example-network"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
@@ -646,8 +632,7 @@ resource "azurerm_virtual_network" "example" {
   }
 }
 `,
-			expectedHCL: `
-resource "azurerm_virtual_network" "example" {
+			expectedHCL: `resource "azurerm_virtual_network" "example" {
   name                = "example-network"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
@@ -704,8 +689,7 @@ resource "azurerm_kubernetes_cluster" "example" {
   }
 }
 `,
-			expectedHCL: `
-resource "azurerm_kubernetes_cluster" "example" {
+			expectedHCL: `resource "azurerm_kubernetes_cluster" "example" {
   name                = "example-aks1"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
@@ -765,8 +749,7 @@ resource "azurerm_virtual_network" "example" {
   }
 }
 `,
-			expectedHCL: `
-resource "azurerm_virtual_network" "example" {
+			expectedHCL: `resource "azurerm_virtual_network" "example" {
   name                = "example-network"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
@@ -830,8 +813,7 @@ resource "azurerm_kubernetes_cluster" "example" {
   }
 }
 `,
-			expectedHCL: `
-resource "azurerm_kubernetes_cluster" "example" {
+			expectedHCL: `resource "azurerm_kubernetes_cluster" "example" {
   name                = "example-aks1"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
@@ -904,8 +886,7 @@ resource "fake_resource" this {
   }
 }
 `,
-			expectedHCL: `
-resource "azurerm_kubernetes_cluster" "example" {
+			expectedHCL: `resource "azurerm_kubernetes_cluster" "example" {
   name                = "example-aks1"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
@@ -962,7 +943,7 @@ resource "fake_resource" this {
 			tfFile, err := afero.ReadFile(fs, "/main.tf")
 			require.NoError(t, err)
 			actual := string(tfFile)
-			assert.Equal(t, normalizeForCompare(c.expectedHCL), normalizeForCompare(actual))
+			assert.Equal(t, c.expectedHCL, actual)
 		})
 	}
 }

--- a/pkg/transform_sort_blocks_in_file_test.go
+++ b/pkg/transform_sort_blocks_in_file_test.go
@@ -277,6 +277,135 @@ variable "alpha" {
 	}
 }
 
+// TestSortBlocksInFile_NoStrayWhitespace pins the file-boundary whitespace
+// behaviour: after sorting blocks within a file, the file on disk must not
+// have leading blank lines or more than one trailing blank line, and stray
+// blank lines left over from removed/re-added blocks must be collapsed. We
+// compare raw bytes (no `formatHcl` trim) because the bug we are guarding
+// against is precisely about file-boundary blanks.
+func TestSortBlocksInFile_NoStrayWhitespace(t *testing.T) {
+	mptf := `
+transform "sort_blocks_in_file" this {
+  file_name     = "variables.tf"
+  desired_order = ["variable.alpha", "variable.bravo", "variable.charlie"]
+}
+`
+	stub := gostub.Stub(&filesystem.Fs, fakeFs(map[string]string{
+		"/variables.tf": `variable "charlie" {
+  type        = string
+  description = "C variable"
+}
+
+variable "alpha" {
+  type        = string
+  description = "A variable"
+}
+
+variable "bravo" {
+  type        = string
+  description = "B variable"
+}
+`,
+	}))
+	defer stub.Reset()
+
+	readFile, diag := hclsyntax.ParseConfig([]byte(mptf), "test.hcl", hcl.InitialPos)
+	require.Falsef(t, diag.HasErrors(), diag.Error())
+	writeFile, diag := hclwrite.ParseConfig([]byte(mptf), "test.hcl", hcl.InitialPos)
+	require.Falsef(t, diag.HasErrors(), diag.Error())
+	hclBlock := golden.NewHclBlock(readFile.Body.(*hclsyntax.Body).Blocks[0], writeFile.Body().Blocks()[0], nil)
+	cfg, err := pkg.NewMetaProgrammingTFConfig(&pkg.TerraformModuleRef{
+		Dir:    "/",
+		AbsDir: "/",
+	}, nil, []*golden.HclBlock{hclBlock}, nil, context.TODO())
+	require.NoError(t, err)
+	plan, err := pkg.RunMetaProgrammingTFPlan(cfg)
+	require.NoError(t, err)
+	require.NoError(t, plan.Apply())
+
+	actual, err := afero.ReadFile(filesystem.Fs, "/variables.tf")
+	require.NoError(t, err)
+	expected := `variable "alpha" {
+  type        = string
+  description = "A variable"
+}
+
+variable "bravo" {
+  type        = string
+  description = "B variable"
+}
+
+variable "charlie" {
+  type        = string
+  description = "C variable"
+}
+`
+	assert.Equal(t, expected, string(actual))
+}
+
+// TestSortBlocksInFile_PullsFromOtherFileNoStrayWhitespace mirrors the AVM
+// pre-commit scenario where some `variable` blocks live in `main.tf` and need
+// to be pulled into `variables.tf`. The file the blocks come from must not be
+// left with stray blank lines, and the destination file must not have leading
+// blanks.
+func TestSortBlocksInFile_PullsFromOtherFileNoStrayWhitespace(t *testing.T) {
+	mptf := `
+transform "sort_blocks_in_file" this {
+  file_name     = "variables.tf"
+  desired_order = ["variable.alpha", "variable.bravo"]
+}
+`
+	stub := gostub.Stub(&filesystem.Fs, fakeFs(map[string]string{
+		"/main.tf": `variable "alpha" {
+  type = string
+}
+
+resource "fake_resource" "keep" {
+  attr = "keep"
+}
+
+variable "bravo" {
+  type = string
+}
+`,
+	}))
+	defer stub.Reset()
+
+	readFile, diag := hclsyntax.ParseConfig([]byte(mptf), "test.hcl", hcl.InitialPos)
+	require.Falsef(t, diag.HasErrors(), diag.Error())
+	writeFile, diag := hclwrite.ParseConfig([]byte(mptf), "test.hcl", hcl.InitialPos)
+	require.Falsef(t, diag.HasErrors(), diag.Error())
+	hclBlock := golden.NewHclBlock(readFile.Body.(*hclsyntax.Body).Blocks[0], writeFile.Body().Blocks()[0], nil)
+	cfg, err := pkg.NewMetaProgrammingTFConfig(&pkg.TerraformModuleRef{
+		Dir:    "/",
+		AbsDir: "/",
+	}, nil, []*golden.HclBlock{hclBlock}, nil, context.TODO())
+	require.NoError(t, err)
+	plan, err := pkg.RunMetaProgrammingTFPlan(cfg)
+	require.NoError(t, err)
+	require.NoError(t, plan.Apply())
+
+	mainActual, err := afero.ReadFile(filesystem.Fs, "/main.tf")
+	require.NoError(t, err)
+	expectedMain := `resource "fake_resource" "keep" {
+  attr = "keep"
+}
+`
+	assert.Equal(t, expectedMain, string(mainActual))
+
+	varsActual, err := afero.ReadFile(filesystem.Fs, "/variables.tf")
+	require.NoError(t, err)
+	expectedVars := `variable "alpha" {
+  type = string
+}
+
+variable "bravo" {
+  type = string
+}
+`
+	assert.Equal(t, expectedVars, string(varsActual))
+}
+
 func TestSortBlocksInFile_EmptyDesiredOrderIsError(t *testing.T) {
 	mptf := `
 transform "sort_blocks_in_file" this {

--- a/pkg/transform_update_in_place_test.go
+++ b/pkg/transform_update_in_place_test.go
@@ -556,3 +556,16 @@ func newHclBlocks(t *testing.T, code string) []*golden.HclBlock {
 func formatHcl(inputHcl string) string {
 	return strings.Trim(string(hclwrite.Format([]byte(inputHcl))), "\n")
 }
+
+// normalizeForCompare strips leading and trailing blank lines and forces a
+// single trailing newline (the canonical shape produced by
+// terraform.normalizeFileWhitespace on save). Use this when an `expected`
+// literal includes incidental leading/trailing newlines from Go raw-string
+// formatting.
+func normalizeForCompare(s string) string {
+	s = strings.Trim(s, "\n")
+	if s == "" {
+		return ""
+	}
+	return s + "\n"
+}

--- a/pkg/transform_update_in_place_test.go
+++ b/pkg/transform_update_in_place_test.go
@@ -556,16 +556,3 @@ func newHclBlocks(t *testing.T, code string) []*golden.HclBlock {
 func formatHcl(inputHcl string) string {
 	return strings.Trim(string(hclwrite.Format([]byte(inputHcl))), "\n")
 }
-
-// normalizeForCompare strips leading and trailing blank lines and forces a
-// single trailing newline (the canonical shape produced by
-// terraform.normalizeFileWhitespace on save). Use this when an `expected`
-// literal includes incidental leading/trailing newlines from Go raw-string
-// formatting.
-func normalizeForCompare(s string) string {
-	s = strings.Trim(s, "\n")
-	if s == "" {
-		return ""
-	}
-	return s + "\n"
-}


### PR DESCRIPTION
## Why

The first real consumer of `sort_blocks_in_file` and `move_block` (the avmfix replacement work in `Azure/avm-terraform-governance`) surfaced that running these transforms against a real AVM module produces files with 3-8 stray leading blank lines and 1 stray trailing blank line in `variables.tf` / `outputs.tf`.

Root cause: `hclwrite.Body.RemoveBlock` removes the block but **leaves the surrounding newline tokens in place**. When `sort_blocks_in_file` removes N blocks and re-appends them in a new order, the N-1 inter-block newlines that lived between them stay at the top of the file, and each `AddBlock` unconditionally tacks on another trailing newline. `avmfix` used to mask this with its own format pass; `hclwrite.Format()` alone does not collapse leading or trailing file-boundary blanks, and neither does `terraform fmt`.

This blocks the downstream migration from producing a byte-clean diff against the existing avmfix output, even though the semantic result is correct.

## What

`Module.SaveToDisk` now wraps `hclwrite.Format` with a new token-level whitespace normalizer (`pkg/terraform/normalize_whitespace.go`). The normalizer walks the parsed token stream, tracks brace depth and heredoc state, and at brace-depth 0 (outside any block body) and outside heredocs:

- strips leading blank lines from each file
- collapses runs of 3+ consecutive `TokenNewline` to 2 (= at most 1 blank line)
- ensures the file ends with exactly one trailing `\n`

Inside blocks (depth > 0) and inside heredoc bodies, whitespace passes through untouched - so:

- `reorder_attributes` v2's intentional blank lines (head -> middle, middle -> tail, leading line before a nested block) are preserved
- multi-line heredoc string content survives unchanged

On parse failure the normalizer returns the input unchanged, so malformed HCL is never corrupted (verified by the pre-existing `TestNewBlockTransform_MalformedNewBlockShouldNotBlockSave`).

## Tests

- New `pkg/terraform/normalize_whitespace_test.go` - 13-case table test covering empty, whitespace-only, canonical, leading-strip, trailing-strip, 3+ collapse, single-blank preservation, no-blank, intra-block blank preservation, heredoc preservation, combined, malformed (fallback), comment-only - plus an idempotency test on representative inputs.
- New `pkg/transform_sort_blocks_in_file_test.go` cases (`TestSortBlocksInFile_NoStrayWhitespace`, `TestSortBlocksInFile_PullsFromOtherFileNoStrayWhitespace`) that read the saved bytes back from disk and assert no leading/trailing blanks. These are the regression guards for the original bug report.
- Existing test expectations updated where the canonical file shape (single trailing `\n`, no leading blanks) changed the literal. For tests that compare large multi-line `expectedHCL` blocks, a small `normalizeForCompare` helper was added next to `formatHcl` (`pkg/transform_update_in_place_test.go`) and applied at the assertion site, rather than rewriting dozens of literals.

Full suite: `cmd`, `pkg`, `pkg/backup`, `pkg/terraform` all `ok`. Lint clean (`golangci/golangci-lint:v2.4.0-alpine`).

## Downstream

Unblocks the avmfix-replacement migration PR in `Azure/avm-terraform-governance` (branch `jaredfholgate/jaredfholgate-drop-avmfix-mapotf-v0-1-0`). Once this lands and is tagged `v0.1.1`, that PR bumps `container/version.env`'s `MAPOTF_VERSION` to the new SHA and produces a byte-clean migration diff.
