### PR TITLE
Pin workflow actions to latest commit SHAs

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -21,21 +21,21 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
       - name: Set up Go
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b #v5.4.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
           go-version-file: go.mod
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd #v3.1.2
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e #v4.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@45775bd8235c68ba998cffa5171334d58593da47 #v3.28.15
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e #v4.36.2
         with:
           languages: go
       - name: Run build
         run: |
           go build github.com/Azure/mapotf
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@45775bd8235c68ba998cffa5171334d58593da47 #v3.28.15
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e #v4.36.2
       - name: Run tests
 
         run: go test -v github.com/Azure/mapotf/...
@@ -44,5 +44,5 @@ jobs:
         run: |
           docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v2.12.2-alpine golangci-lint run -v --timeout=3600s
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@955a68d0d19f4afb7503068f95059f7d0c529017 #v2.22.3
+        uses: securego/gosec@9e6a9843d7a4a6e3e9a8539b02612c8a4aa3f889 #v2.27.1
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -28,7 +28,7 @@ jobs:
         run: go test ./...
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 #v7.2.2
         with:
           distribution: goreleaser
           version: '~> v2'


### PR DESCRIPTION
## Summary
- Update GitHub Actions workflow steps to latest stable action versions
- Pin all action references to full commit SHAs as a security best practice
- Keep version comments aligned with pinned revisions

## Workflows updated
- `.github/workflows/pr-check.yml`
- `.github/workflows/release.yml`

## Action version changes
| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v4.2.2 | v6.0.3 |
| `actions/setup-go` | v5.4.0 | v6.4.0 |
| `hashicorp/setup-terraform` | v3.1.2 | v4.0.1 |
| `github/codeql-action/init` | v3.28.15 | v4.36.2 |
| `github/codeql-action/analyze` | v3.28.15 | v4.36.2 |
| `securego/gosec` | v2.22.3 | v2.27.1 |
| `goreleaser/goreleaser-action` | v6 (tag) | v7.2.2 |

Release workflow steps that were previously pinned only to floating major tags (`@v4`, `@v5`, `@v6`) are now pinned to full commit SHAs as well.