### PR TITLE
fix: blank-line edge cases (adjacent same-kind blocks, empty desired_order) + opt-in grouping — v0.1.2

### DIFF
--- a/cmd/transform.go
+++ b/cmd/transform.go
@@ -6,26 +6,32 @@ import (
 	"github.com/Azure/golden"
 	"github.com/Azure/mapotf/pkg"
 	"github.com/Azure/mapotf/pkg/backup"
+	"github.com/Azure/mapotf/pkg/terraform"
 	"github.com/spf13/cobra"
 	"os"
 )
 
 func NewTransformCmd() *cobra.Command {
 	recursive := false
+	keepAdjacentBlocks := false
 
 	transformCmd := &cobra.Command{
 		Use:   "transform",
-		Short: "Apply the transforms, mapotf transform [-r] --tf-dir [] --mptf-dir  [path to config files], support mutilple mptf dirs",
+		Short: "Apply the transforms, mapotf transform [-r] [--keep-adjacent-blocks] --tf-dir [] --mptf-dir  [path to config files], support mutilple mptf dirs",
 		FParseErrWhitelist: cobra.FParseErrWhitelist{
 			UnknownFlags: true,
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			terraform.SetNormalizeOptions(terraform.NormalizeOptions{
+				KeepAdjacentSameKindUnlabeledBlocks: keepAdjacentBlocks,
+			})
 			_, err := transform(recursive, cmd.Context())
 			return err
 		},
 	}
 
 	transformCmd.Flags().BoolVarP(&recursive, "recursive", "r", false, "Apply transforms to all modules or not, default to the root module only.")
+	transformCmd.Flags().BoolVar(&keepAdjacentBlocks, "keep-adjacent-blocks", false, "Keep adjacent unlabeled same-kind root blocks (e.g. two `locals {}` or two `moved {}` blocks) on directly consecutive lines with no blank line between them. Labeled blocks such as `variable \"x\" {}` or `resource \"t\" \"n\" {}` are unaffected and always get a blank line between siblings. Off by default: every pair of root blocks is separated by exactly one blank line.")
 	return transformCmd
 }
 

--- a/pkg/terraform/normalize_whitespace.go
+++ b/pkg/terraform/normalize_whitespace.go
@@ -9,6 +9,48 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
 
+// NormalizeOptions tunes normalizeFileWhitespace's inter-block layout
+// behaviour. The zero value is the default behaviour applied by SaveToDisk
+// when no CLI override is provided.
+type NormalizeOptions struct {
+	// KeepAdjacentSameKindUnlabeledBlocks, when true, suppresses the blank
+	// line between adjacent root-level blocks that have no labels AND share
+	// the same leading identifier (e.g. two `locals {}` or two `moved {}`).
+	// Labeled blocks (`variable "a" {}` and `variable "b" {}`, two `resource`
+	// blocks of the same type, etc.) are unaffected — they always get a
+	// blank line between them.
+	//
+	// Default false: every pair of root blocks gets exactly one blank line
+	// between them regardless of kind or label, matching the v0.1.1
+	// normalizer's behaviour. This is the safe default because most existing
+	// Terraform style guides and tooling pipelines expect a blank line
+	// between every root block.
+	//
+	// Set to true via the `--keep-adjacent-blocks` CLI flag when a target
+	// repository prefers grouping adjacent same-kind unlabeled blocks
+	// together (matches the way `terraform fmt` leaves hand-written
+	// adjacent `locals {}` blocks).
+	KeepAdjacentSameKindUnlabeledBlocks bool
+}
+
+var defaultNormalizeOptions NormalizeOptions
+
+// SetNormalizeOptions overrides the package-level options consulted by
+// SaveToDisk when it calls normalizeFileWhitespace. Intended to be called
+// once at startup from the CLI based on user flags. Not goroutine-safe;
+// callers should set this before kicking off any transform that may write
+// to disk.
+func SetNormalizeOptions(opts NormalizeOptions) {
+	defaultNormalizeOptions = opts
+}
+
+// NormalizeOptionsValue returns the current package-level NormalizeOptions
+// previously set via SetNormalizeOptions (or the zero value if none was
+// set). Exposed for tests and diagnostic logging.
+func NormalizeOptionsValue() NormalizeOptions {
+	return defaultNormalizeOptions
+}
+
 // normalizeFileWhitespace strips stray blank lines that transforms like
 // `sort_blocks_in_file` and `move_block` can leave behind when they remove a
 // block from a file (hclwrite preserves the surrounding newline tokens) and
@@ -29,6 +71,19 @@ import (
 //   - the file always ends with exactly one trailing newline (zero trailing
 //     blank lines), unless the file is empty.
 //
+// Optional opt-in behaviour, enabled by setting
+// NormalizeOptions.KeepAdjacentSameKindUnlabeledBlocks: when the
+// just-closed root block has no labels (e.g. `locals {}`, `terraform {}`,
+// `moved {}`, `removed {}`) and the next non-newline token at depth 0 is
+// an identifier whose bytes match the closed block's leading identifier,
+// the two blocks are emitted adjacent (one newline between them, no blank
+// line). Same-kind unlabeled siblings — the canonical case being two
+// `locals {}` blocks declared in the same file — group together the way
+// they would have under `terraform fmt`. Labeled siblings (`variable "a"
+// {}` and `variable "b" {}`, two `resource` blocks of the same type, etc.)
+// still get the blank line — they represent distinct named entities and
+// conventional style separates them.
+//
 // Whitespace inside a block (depth > 0) is preserved verbatim so the
 // intentional blank lines emitted by `reorder_attributes` (between
 // head/middle/tail and before nested blocks) are not affected. Heredoc
@@ -39,12 +94,20 @@ import (
 // If `src` does not parse as valid HCL, it is returned unchanged so we never
 // corrupt files we cannot reason about.
 func normalizeFileWhitespace(src []byte) []byte {
+	return normalizeFileWhitespaceWithOptions(src, defaultNormalizeOptions)
+}
+
+// normalizeFileWhitespaceWithOptions is the options-aware form of
+// normalizeFileWhitespace. Tests use it directly; production code goes
+// through normalizeFileWhitespace which reads the package-level
+// defaultNormalizeOptions set by SetNormalizeOptions.
+func normalizeFileWhitespaceWithOptions(src []byte, opts NormalizeOptions) []byte {
 	wf, diag := hclwrite.ParseConfig(src, "", hcl.Pos{Line: 1, Column: 1})
 	if diag.HasErrors() || wf == nil {
 		return src
 	}
 	tokens := wf.BuildTokens(nil)
-	return renderNormalizedTokens(tokens)
+	return renderNormalizedTokens(tokens, opts)
 }
 
 // renderNormalizedTokens walks `tokens` and emits their bytes with depth-0
@@ -53,17 +116,25 @@ func normalizeFileWhitespace(src []byte) []byte {
 // The token stream is the post-format hclwrite representation, so:
 //   - braces are TokenOBrace / TokenCBrace,
 //   - newlines outside heredocs are TokenNewline,
+//   - block labels (e.g. the `"x"` and `"y"` in `resource "x" "y" {}`) are
+//     bracketed by TokenOQuote / TokenCQuote with a TokenQuotedLit between,
 //   - heredoc bodies are bracketed by TokenOHeredoc / TokenCHeredoc and any
 //     newlines inside them live in TokenStringLit bytes (no standalone
 //     TokenNewline appears between them).
-func renderNormalizedTokens(tokens hclwrite.Tokens) []byte {
+func renderNormalizedTokens(tokens hclwrite.Tokens, opts NormalizeOptions) []byte {
 	var (
-		out               bytes.Buffer
-		depth             int
-		inHeredoc         bool
-		pendingNewlines   int
-		emittedAny        bool
-		lastWasRootCBrace bool
+		out                 bytes.Buffer
+		depth               int
+		inHeredoc           bool
+		pendingNewlines     int
+		emittedAny          bool
+		lastWasRootCBrace   bool
+		pendingBlockType    string
+		pendingBlockLabeled bool
+		currentBlockType    string
+		currentBlockLabeled bool
+		lastBlockType       string
+		lastBlockLabeled    bool
 	)
 
 	emitNewlines := func(n int) {
@@ -88,7 +159,7 @@ func renderNormalizedTokens(tokens hclwrite.Tokens) []byte {
 		out.Write(tok.Bytes)
 	}
 
-	flushBeforeContent := func() {
+	flushBeforeContent := func(tok *hclwrite.Token) {
 		if pendingNewlines == 0 {
 			return
 		}
@@ -98,7 +169,17 @@ func renderNormalizedTokens(tokens hclwrite.Tokens) []byte {
 		}
 		if depth == 0 {
 			if lastWasRootCBrace {
-				emitNewlines(2)
+				sameKindUnlabeledAdjacent := opts.KeepAdjacentSameKindUnlabeledBlocks &&
+					!lastBlockLabeled &&
+					lastBlockType != "" &&
+					tok != nil &&
+					tok.Type == hclsyntax.TokenIdent &&
+					string(tok.Bytes) == lastBlockType
+				if sameKindUnlabeledAdjacent {
+					emitNewlines(1)
+				} else {
+					emitNewlines(2)
+				}
 			} else {
 				flushPending(2)
 			}
@@ -113,7 +194,7 @@ func renderNormalizedTokens(tokens hclwrite.Tokens) []byte {
 			pendingNewlines = 0
 			continue
 		case hclsyntax.TokenOHeredoc:
-			flushBeforeContent()
+			flushBeforeContent(tok)
 			emittedAny = true
 			lastWasRootCBrace = false
 			inHeredoc = true
@@ -133,18 +214,42 @@ func renderNormalizedTokens(tokens hclwrite.Tokens) []byte {
 				writeRaw(tok)
 				continue
 			}
-			flushBeforeContent()
+			flushBeforeContent(tok)
 			emittedAny = true
 			writeRaw(tok)
 			switch tok.Type {
 			case hclsyntax.TokenOBrace:
+				if depth == 0 {
+					currentBlockType = pendingBlockType
+					currentBlockLabeled = pendingBlockLabeled
+					pendingBlockType = ""
+					pendingBlockLabeled = false
+				}
 				depth++
 				lastWasRootCBrace = false
 			case hclsyntax.TokenCBrace:
 				if depth > 0 {
 					depth--
 				}
-				lastWasRootCBrace = depth == 0
+				if depth == 0 {
+					lastBlockType = currentBlockType
+					lastBlockLabeled = currentBlockLabeled
+					currentBlockType = ""
+					currentBlockLabeled = false
+					lastWasRootCBrace = true
+				} else {
+					lastWasRootCBrace = false
+				}
+			case hclsyntax.TokenIdent:
+				if depth == 0 && pendingBlockType == "" {
+					pendingBlockType = string(tok.Bytes)
+				}
+				lastWasRootCBrace = false
+			case hclsyntax.TokenOQuote:
+				if depth == 0 && pendingBlockType != "" {
+					pendingBlockLabeled = true
+				}
+				lastWasRootCBrace = false
 			default:
 				lastWasRootCBrace = false
 			}

--- a/pkg/terraform/normalize_whitespace_test.go
+++ b/pkg/terraform/normalize_whitespace_test.go
@@ -120,6 +120,46 @@ func TestNormalizeFileWhitespace(t *testing.T) {
 			in:   "# just a comment\n",
 			want: "# just a comment\n",
 		},
+		{
+			name: "default mode: adjacent unlabeled same-kind blocks (locals) get a blank line between them",
+			in:   "locals {\n  a = 1\n}\nlocals {\n  b = 2\n}\n",
+			want: "locals {\n  a = 1\n}\n\nlocals {\n  b = 2\n}\n",
+		},
+		{
+			name: "default mode: three adjacent unlabeled same-kind blocks (locals) each get a blank line between them",
+			in:   "locals {\n  a = 1\n}\nlocals {\n  b = 2\n}\nlocals {\n  c = 3\n}\n",
+			want: "locals {\n  a = 1\n}\n\nlocals {\n  b = 2\n}\n\nlocals {\n  c = 3\n}\n",
+		},
+		{
+			name: "default mode: adjacent moved blocks get a blank line between them",
+			in:   "moved {\n  from = a.b\n  to   = c.d\n}\nmoved {\n  from = e.f\n  to   = g.h\n}\n",
+			want: "moved {\n  from = a.b\n  to   = c.d\n}\n\nmoved {\n  from = e.f\n  to   = g.h\n}\n",
+		},
+		{
+			name: "default mode: adjacent unlabeled different-kind blocks still get blank",
+			in:   "locals {\n  a = 1\n}\nterraform {\n  required_version = \"~> 1.0\"\n}\n",
+			want: "locals {\n  a = 1\n}\n\nterraform {\n  required_version = \"~> 1.0\"\n}\n",
+		},
+		{
+			name: "default mode: labeled same-type blocks still get blank line (variables)",
+			in:   "variable \"a\" {}\nvariable \"b\" {}\n",
+			want: "variable \"a\" {}\n\nvariable \"b\" {}\n",
+		},
+		{
+			name: "default mode: labeled same-type blocks still get blank line (resources)",
+			in:   "resource \"x\" \"a\" {}\nresource \"x\" \"b\" {}\n",
+			want: "resource \"x\" \"a\" {}\n\nresource \"x\" \"b\" {}\n",
+		},
+		{
+			name: "default mode: existing single blank between same-kind unlabeled blocks is preserved",
+			in:   "locals {\n  a = 1\n}\n\nlocals {\n  b = 2\n}\n",
+			want: "locals {\n  a = 1\n}\n\nlocals {\n  b = 2\n}\n",
+		},
+		{
+			name: "default mode: many blank lines between same-kind unlabeled blocks collapse to exactly one blank",
+			in:   "locals {\n  a = 1\n}\n\n\n\n\nlocals {\n  b = 2\n}\n",
+			want: "locals {\n  a = 1\n}\n\nlocals {\n  b = 2\n}\n",
+		},
 	}
 
 	for _, tc := range cases {
@@ -129,6 +169,141 @@ func TestNormalizeFileWhitespace(t *testing.T) {
 				t.Errorf("normalizeFileWhitespace mismatch\n--- want ---\n%q\n--- got ---\n%q", tc.want, got)
 			}
 		})
+	}
+}
+
+// TestNormalizeFileWhitespace_KeepAdjacentSameKindUnlabeledBlocks exercises
+// the opt-in behaviour enabled by
+// NormalizeOptions.KeepAdjacentSameKindUnlabeledBlocks=true. With the flag
+// on, adjacent root-level blocks that share the same leading identifier AND
+// have no labels are kept adjacent (no blank line between them). Labeled
+// sibling blocks (resource, data, variable, etc.) still get the blank line
+// regardless, and unlabeled siblings of *different* kinds also still get
+// the blank line.
+func TestNormalizeFileWhitespace_KeepAdjacentSameKindUnlabeledBlocks(t *testing.T) {
+	opts := NormalizeOptions{KeepAdjacentSameKindUnlabeledBlocks: true}
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "opt-in: adjacent unlabeled same-kind blocks stay adjacent (locals)",
+			in:   "locals {\n  a = 1\n}\nlocals {\n  b = 2\n}\n",
+			want: "locals {\n  a = 1\n}\nlocals {\n  b = 2\n}\n",
+		},
+		{
+			name: "opt-in: three adjacent unlabeled same-kind blocks stay adjacent (locals)",
+			in:   "locals {\n  a = 1\n}\nlocals {\n  b = 2\n}\n\n\nlocals {\n  c = 3\n}\n",
+			want: "locals {\n  a = 1\n}\nlocals {\n  b = 2\n}\nlocals {\n  c = 3\n}\n",
+		},
+		{
+			name: "opt-in: adjacent unlabeled same-kind blocks stay adjacent (moved)",
+			in:   "moved {\n  from = a.b\n  to   = c.d\n}\nmoved {\n  from = e.f\n  to   = g.h\n}\n",
+			want: "moved {\n  from = a.b\n  to   = c.d\n}\nmoved {\n  from = e.f\n  to   = g.h\n}\n",
+		},
+		{
+			name: "opt-in: adjacent unlabeled different-kind blocks still get blank",
+			in:   "locals {\n  a = 1\n}\nterraform {\n  required_version = \"~> 1.0\"\n}\n",
+			want: "locals {\n  a = 1\n}\n\nterraform {\n  required_version = \"~> 1.0\"\n}\n",
+		},
+		{
+			name: "opt-in: labeled same-type blocks still get blank line (variables)",
+			in:   "variable \"a\" {}\nvariable \"b\" {}\n",
+			want: "variable \"a\" {}\n\nvariable \"b\" {}\n",
+		},
+		{
+			name: "opt-in: labeled same-type blocks still get blank line (resources)",
+			in:   "resource \"x\" \"a\" {}\nresource \"x\" \"b\" {}\n",
+			want: "resource \"x\" \"a\" {}\n\nresource \"x\" \"b\" {}\n",
+		},
+		{
+			name: "opt-in: comment between adjacent unlabeled same-kind blocks forces blank line",
+			in:   "locals {\n  a = 1\n}\n# divider\nlocals {\n  b = 2\n}\n",
+			want: "locals {\n  a = 1\n}\n\n# divider\nlocals {\n  b = 2\n}\n",
+		},
+		{
+			name: "opt-in: unlabeled then labeled does not group",
+			in:   "locals {\n  a = 1\n}\nvariable \"x\" {}\n",
+			want: "locals {\n  a = 1\n}\n\nvariable \"x\" {}\n",
+		},
+		{
+			name: "opt-in: labeled then unlabeled does not group",
+			in:   "variable \"x\" {}\nlocals {\n  a = 1\n}\n",
+			want: "variable \"x\" {}\n\nlocals {\n  a = 1\n}\n",
+		},
+		{
+			name: "opt-in: existing blank between same-kind unlabeled blocks is collapsed away",
+			in:   "locals {\n  a = 1\n}\n\nlocals {\n  b = 2\n}\n",
+			want: "locals {\n  a = 1\n}\nlocals {\n  b = 2\n}\n",
+		},
+		{
+			name: "opt-in: many blank lines between same-kind unlabeled blocks collapse to none",
+			in:   "locals {\n  a = 1\n}\n\n\n\n\nlocals {\n  b = 2\n}\n",
+			want: "locals {\n  a = 1\n}\nlocals {\n  b = 2\n}\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := string(normalizeFileWhitespaceWithOptions([]byte(tc.in), opts))
+			if got != tc.want {
+				t.Errorf("normalizeFileWhitespaceWithOptions mismatch\n--- want ---\n%q\n--- got ---\n%q", tc.want, got)
+			}
+		})
+	}
+}
+
+// TestNormalizeFileWhitespace_DefaultMatchesZeroOptions verifies that the
+// shorthand normalizeFileWhitespace and the explicit
+// normalizeFileWhitespaceWithOptions called with a zero NormalizeOptions
+// value produce identical output, and that the package-level
+// defaultNormalizeOptions starts at its zero value. This pins the
+// "default-off" contract: SetNormalizeOptions has not been called in tests,
+// so the production save path goes through the safe, always-blank rules.
+func TestNormalizeFileWhitespace_DefaultMatchesZeroOptions(t *testing.T) {
+	if got := NormalizeOptionsValue(); got != (NormalizeOptions{}) {
+		t.Fatalf("expected zero-value default options, got %#v", got)
+	}
+	inputs := []string{
+		"locals {\n  a = 1\n}\nlocals {\n  b = 2\n}\n",
+		"moved {\n  from = a.b\n  to   = c.d\n}\nmoved {\n  from = e.f\n  to   = g.h\n}\n",
+		"variable \"a\" {}\nvariable \"b\" {}\n",
+		"",
+		"\n\n",
+	}
+	for _, in := range inputs {
+		viaDefault := string(normalizeFileWhitespace([]byte(in)))
+		viaZeroOpts := string(normalizeFileWhitespaceWithOptions([]byte(in), NormalizeOptions{}))
+		if viaDefault != viaZeroOpts {
+			t.Errorf("default and zero-options differ for input %q:\ndefault: %q\nzero   : %q", in, viaDefault, viaZeroOpts)
+		}
+	}
+}
+
+// TestNormalizeFileWhitespace_SetNormalizeOptionsRoundtrip verifies the
+// package-level setter is wired correctly: setting opt-in and re-running
+// the shorthand entry point switches behaviour, and clearing it puts the
+// behaviour back to the default.
+func TestNormalizeFileWhitespace_SetNormalizeOptionsRoundtrip(t *testing.T) {
+	saved := NormalizeOptionsValue()
+	t.Cleanup(func() { SetNormalizeOptions(saved) })
+
+	in := "locals {\n  a = 1\n}\nlocals {\n  b = 2\n}\n"
+
+	SetNormalizeOptions(NormalizeOptions{})
+	if got := string(normalizeFileWhitespace([]byte(in))); got != "locals {\n  a = 1\n}\n\nlocals {\n  b = 2\n}\n" {
+		t.Errorf("after SetNormalizeOptions({}), got %q", got)
+	}
+
+	SetNormalizeOptions(NormalizeOptions{KeepAdjacentSameKindUnlabeledBlocks: true})
+	if got := string(normalizeFileWhitespace([]byte(in))); got != "locals {\n  a = 1\n}\nlocals {\n  b = 2\n}\n" {
+		t.Errorf("after SetNormalizeOptions(opt-in), got %q", got)
+	}
+
+	SetNormalizeOptions(NormalizeOptions{})
+	if got := string(normalizeFileWhitespace([]byte(in))); got != "locals {\n  a = 1\n}\n\nlocals {\n  b = 2\n}\n" {
+		t.Errorf("after reset to defaults, got %q", got)
 	}
 }
 
@@ -143,12 +318,42 @@ func TestNormalizeFileWhitespace_Idempotent(t *testing.T) {
 		"locals {\n  s = <<-EOT\n    a\n  EOT\n}\nvariable \"x\" {}\n",
 		"resource \"x\" \"y\" {\n  a = 1\n\n  nested {\n    b = 2\n  }\n}\n",
 		"resource \"x\" \"y\" {\n  nested_one {\n    a = 1\n  }\n  nested_two {\n    b = 2\n  }\n}\n",
+		"locals {\n  a = 1\n}\nlocals {\n  b = 2\n}\n",
+		"locals {\n  a = 1\n}\nlocals {\n  b = 2\n}\nlocals {\n  c = 3\n}\n",
+		"locals {\n  a = 1\n}\n\nterraform {\n  required_version = \"~> 1.0\"\n}\n",
+		"moved {\n  from = a.b\n  to   = c.d\n}\nmoved {\n  from = e.f\n  to   = g.h\n}\n",
+		"locals {\n  a = 1\n}\n\n# divider\nlocals {\n  b = 2\n}\n",
 	}
 	for _, in := range inputs {
 		first := normalizeFileWhitespace([]byte(in))
 		second := normalizeFileWhitespace(first)
 		if string(first) != string(second) {
 			t.Errorf("not idempotent for input %q:\nfirst : %q\nsecond: %q", in, first, second)
+		}
+	}
+}
+
+// TestNormalizeFileWhitespace_Idempotent_KeepAdjacent verifies the opt-in
+// rendering is also idempotent. The inputs include the canonical adjacent
+// same-kind cases (locals, moved) that under opt-in mode collapse to no
+// blank between them — and that collapsed form must round-trip cleanly.
+func TestNormalizeFileWhitespace_Idempotent_KeepAdjacent(t *testing.T) {
+	opts := NormalizeOptions{KeepAdjacentSameKindUnlabeledBlocks: true}
+	inputs := []string{
+		"locals {\n  a = 1\n}\nlocals {\n  b = 2\n}\n",
+		"locals {\n  a = 1\n}\n\nlocals {\n  b = 2\n}\n",
+		"locals {\n  a = 1\n}\nlocals {\n  b = 2\n}\nlocals {\n  c = 3\n}\n",
+		"moved {\n  from = a.b\n  to   = c.d\n}\nmoved {\n  from = e.f\n  to   = g.h\n}\n",
+		"locals {\n  a = 1\n}\nlocals {\n  b = 2\n}\n\nterraform {\n  required_version = \"~> 1.0\"\n}\n",
+		"locals {\n  a = 1\n}\n\n# divider\nlocals {\n  b = 2\n}\n",
+		"variable \"a\" {}\nvariable \"b\" {}\n",
+		"resource \"x\" \"a\" {}\nresource \"x\" \"b\" {}\n",
+	}
+	for _, in := range inputs {
+		first := normalizeFileWhitespaceWithOptions([]byte(in), opts)
+		second := normalizeFileWhitespaceWithOptions(first, opts)
+		if string(first) != string(second) {
+			t.Errorf("not idempotent (opt-in) for input %q:\nfirst : %q\nsecond: %q", in, first, second)
 		}
 	}
 }

--- a/pkg/transform_reorder_attributes.go
+++ b/pkg/transform_reorder_attributes.go
@@ -28,9 +28,13 @@ var _ Transform = &ReorderAttributesTransform{}
 //   - When `head_tail_line_breaks` is true (default) a blank line is inserted
 //     between the head section and the middle, and between the middle and the
 //     tail section. Set to `false` to suppress these blank lines.
-//   - Every nested block in the output is preceded by a blank line — if a
-//     blank line is already there (because of the head/tail rule above) no
-//     extra blank line is inserted.
+//   - Every nested block in the output is preceded by a blank line, except
+//     when the previous element is a nested block sharing the same orderable
+//     name. Adjacent same-kind siblings (e.g. two `validation {}` blocks of
+//     a variable, two `dynamic "subnet" {}` blocks of a resource) stay
+//     grouped without a blank line between them, matching typical Terraform
+//     formatting. If a section boundary (head/tail) coincides with the
+//     adjacency the section blank line still wins.
 //   - Names in `head_attributes` / `tail_attributes` that are not present on
 //     the block are silently skipped.
 //   - The same name in both `head_attributes` and `tail_attributes` is a
@@ -224,11 +228,17 @@ func sortReorderMiddle(elems []reorderElement, alphabetical bool) {
 //   - `headTailLineBreaks` controls whether blank lines are emitted at the
 //     head→middle and middle→tail section boundaries.
 //
-// A blank line is always emitted before a nested block (so user-facing
-// readability matches typical Terraform style). When the head→middle and
-// middle→tail boundaries collapse to the same index (empty middle) only one
-// blank line is emitted, because `needBlank` is a single boolean per
-// iteration.
+// A blank line is emitted before a nested block to match typical Terraform
+// formatting, with one exception: when the previous element is a nested
+// block sharing the same orderable name (e.g. two `validation {}` siblings,
+// two `dynamic "subnet" {}` siblings), no blank line is inserted so the
+// group stays visually adjacent. A section boundary still forces a blank
+// line, even when it falls between same-kind siblings, because the user
+// asked for that separator explicitly.
+//
+// When the head→middle and middle→tail boundaries collapse to the same
+// index (empty middle) only one blank line is emitted, because `needBlank`
+// is a single boolean per iteration.
 func emitReorderElements(body *hclwrite.Body, elements []reorderElement, headEnd, tailStart int, headTailLineBreaks bool) {
 	for i, el := range elements {
 		if i > 0 {
@@ -240,7 +250,11 @@ func emitReorderElements(body *hclwrite.Body, elements []reorderElement, headEnd
 				needBlank = true
 			}
 			if el.isNested {
-				needBlank = true
+				prev := elements[i-1]
+				sameKindAdjacent := prev.isNested && prev.name == el.name
+				if !sameKindAdjacent {
+					needBlank = true
+				}
 			}
 			if needBlank {
 				body.AppendNewline()

--- a/pkg/transform_reorder_attributes_test.go
+++ b/pkg/transform_reorder_attributes_test.go
@@ -430,6 +430,260 @@ variable "example" {
 }
 `,
 		},
+		{
+			desc: "adjacent_same_name_nested_blocks_stay_adjacent",
+			mptf: `
+transform "reorder_attributes" this {
+  target_block_address = "variable.example"
+  head_attributes      = ["type", "description"]
+}
+`,
+			tfConfig: `
+variable "example" {
+  description = "An example."
+  type        = string
+  validation {
+    condition     = length(var.example) > 0
+    error_message = "Must not be empty."
+  }
+  validation {
+    condition     = length(var.example) < 10
+    error_message = "Must be short."
+  }
+}
+`,
+			expected: `
+variable "example" {
+  type        = string
+  description = "An example."
+
+  validation {
+    condition     = length(var.example) > 0
+    error_message = "Must not be empty."
+  }
+  validation {
+    condition     = length(var.example) < 10
+    error_message = "Must be short."
+  }
+}
+`,
+		},
+		{
+			desc: "three_adjacent_same_name_nested_blocks_all_stay_adjacent",
+			mptf: `
+transform "reorder_attributes" this {
+  target_block_address = "variable.example"
+  head_attributes      = ["type"]
+}
+`,
+			tfConfig: `
+variable "example" {
+  type = string
+  validation {
+    condition     = true
+    error_message = "first"
+  }
+  validation {
+    condition     = true
+    error_message = "second"
+  }
+  validation {
+    condition     = true
+    error_message = "third"
+  }
+}
+`,
+			expected: `
+variable "example" {
+  type = string
+
+  validation {
+    condition     = true
+    error_message = "first"
+  }
+  validation {
+    condition     = true
+    error_message = "second"
+  }
+  validation {
+    condition     = true
+    error_message = "third"
+  }
+}
+`,
+		},
+		{
+			desc: "adjacent_same_label_dynamic_blocks_stay_adjacent",
+			mptf: `
+transform "reorder_attributes" this {
+  target_block_address = "resource.fake_resource.this"
+  head_attributes      = ["count"]
+}
+`,
+			tfConfig: `
+resource "fake_resource" this {
+  count = 1
+  dynamic "subnet" {
+    for_each = var.subnets_a
+    content {
+      name = subnet.value
+    }
+  }
+  dynamic "subnet" {
+    for_each = var.subnets_b
+    content {
+      name = subnet.value
+    }
+  }
+}
+`,
+			expected: `
+resource "fake_resource" this {
+  count = 1
+
+  dynamic "subnet" {
+    for_each = var.subnets_a
+    content {
+      name = subnet.value
+    }
+  }
+  dynamic "subnet" {
+    for_each = var.subnets_b
+    content {
+      name = subnet.value
+    }
+  }
+}
+`,
+		},
+		{
+			desc: "different_label_dynamic_blocks_still_get_blank_between",
+			mptf: `
+transform "reorder_attributes" this {
+  target_block_address = "resource.fake_resource.this"
+  head_attributes      = ["count"]
+}
+`,
+			tfConfig: `
+resource "fake_resource" this {
+  count = 1
+  dynamic "subnet" {
+    for_each = var.subnets
+    content {
+      name = subnet.value
+    }
+  }
+  dynamic "route" {
+    for_each = var.routes
+    content {
+      cidr = route.value
+    }
+  }
+}
+`,
+			expected: `
+resource "fake_resource" this {
+  count = 1
+
+  dynamic "route" {
+    for_each = var.routes
+    content {
+      cidr = route.value
+    }
+  }
+
+  dynamic "subnet" {
+    for_each = var.subnets
+    content {
+      name = subnet.value
+    }
+  }
+}
+`,
+		},
+		{
+			desc: "same_name_nested_with_attr_between_does_not_group",
+			mptf: `
+transform "reorder_attributes" this {
+  target_block_address       = "variable.example"
+  head_attributes            = ["type"]
+  sort_middle_alphabetically = false
+}
+`,
+			tfConfig: `
+variable "example" {
+  type = string
+  validation {
+    condition     = true
+    error_message = "first"
+  }
+  some_attr = "x"
+  validation {
+    condition     = true
+    error_message = "second"
+  }
+}
+`,
+			expected: `
+variable "example" {
+  type = string
+
+  validation {
+    condition     = true
+    error_message = "first"
+  }
+  some_attr = "x"
+
+  validation {
+    condition     = true
+    error_message = "second"
+  }
+}
+`,
+		},
+		{
+			desc: "section_boundary_at_same_name_nested_still_inserts_blank",
+			mptf: `
+transform "reorder_attributes" this {
+  target_block_address = "variable.example"
+  head_attributes      = ["type", "validation"]
+  tail_attributes      = ["depends_on"]
+}
+`,
+			tfConfig: `
+variable "example" {
+  description = "An example."
+  type        = string
+  depends_on  = ["other"]
+  validation {
+    condition     = true
+    error_message = "first"
+  }
+  validation {
+    condition     = true
+    error_message = "second"
+  }
+}
+`,
+			expected: `
+variable "example" {
+  type = string
+
+  validation {
+    condition     = true
+    error_message = "first"
+  }
+  validation {
+    condition     = true
+    error_message = "second"
+  }
+
+  description = "An example."
+
+  depends_on = ["other"]
+}
+`,
+		},
 	}
 
 	for _, c := range cases {

--- a/pkg/transform_sort_blocks_in_file.go
+++ b/pkg/transform_sort_blocks_in_file.go
@@ -21,11 +21,16 @@ var _ Transform = &SortBlocksInFileTransform{}
 //   - An address that does not resolve to a known block is a hard error
 //     (silent skip would mask drift, since `desired_order` is usually
 //     computed from a data source).
+//   - An empty `desired_order` is a no-op. This makes it safe to drive the
+//     list from a data source (e.g. `[for v in data.variable.all.result :
+//     "variable.${v.name}"]`) in module contexts where the data source
+//     resolves to an empty collection — for example `examples/*` directories
+//     that have no `variables.tf`.
 type SortBlocksInFileTransform struct {
 	*golden.BaseBlock
 	*BaseTransform
 	FileName     string   `hcl:"file_name" validate:"endswith=.tf"`
-	DesiredOrder []string `hcl:"desired_order" validate:"required,min=1,unique,dive,min=1"`
+	DesiredOrder []string `hcl:"desired_order" validate:"unique,dive,min=1"`
 }
 
 func (s *SortBlocksInFileTransform) Type() string {
@@ -34,7 +39,7 @@ func (s *SortBlocksInFileTransform) Type() string {
 
 func (s *SortBlocksInFileTransform) Apply() error {
 	if len(s.DesiredOrder) == 0 {
-		return fmt.Errorf("sort_blocks_in_file: desired_order must not be empty")
+		return nil
 	}
 	seen := make(map[string]struct{}, len(s.DesiredOrder))
 	for _, addr := range s.DesiredOrder {

--- a/pkg/transform_sort_blocks_in_file_test.go
+++ b/pkg/transform_sort_blocks_in_file_test.go
@@ -406,15 +406,16 @@ variable "bravo" {
 	assert.Equal(t, expectedVars, string(varsActual))
 }
 
-func TestSortBlocksInFile_EmptyDesiredOrderIsError(t *testing.T) {
+func TestSortBlocksInFile_EmptyDesiredOrderIsNoOp(t *testing.T) {
 	mptf := `
 transform "sort_blocks_in_file" this {
   file_name     = "variables.tf"
   desired_order = []
 }
 `
+	originalVars := "variable \"x\" {\n  type = string\n}\n"
 	stub := gostub.Stub(&filesystem.Fs, fakeFs(map[string]string{
-		"/variables.tf": `variable "x" { type = string }`,
+		"/variables.tf": originalVars,
 	}))
 	defer stub.Reset()
 
@@ -428,7 +429,11 @@ transform "sort_blocks_in_file" this {
 		AbsDir: "/",
 	}, nil, []*golden.HclBlock{hclBlock}, nil, context.TODO())
 	require.NoError(t, err)
-	_, err = pkg.RunMetaProgrammingTFPlan(cfg)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "min")
+	plan, err := pkg.RunMetaProgrammingTFPlan(cfg)
+	require.NoError(t, err)
+	err = plan.Apply()
+	require.NoError(t, err)
+	after, err := afero.ReadFile(filesystem.Fs, "/variables.tf")
+	require.NoError(t, err)
+	assert.Equal(t, originalVars, string(after))
 }


### PR DESCRIPTION
## Summary

Three follow-up fixes uncovered while migrating `Azure/avm-terraform-governance` from `avmfix` to native mapotf transforms. All three commits below address issues that surfaced when v0.1.0 + v0.1.1 were exercised against real AVM modules; together they should produce byte-clean diffs against the avmfix baseline, unblocking the governance migration PR (`Azure/avm-terraform-governance#472`).

## Commits

### 1. `fix(sort_blocks_in_file): empty desired_order is a no-op` (`d36762a`)

`sort_blocks_in_file.desired_order` had `validate:"required,min=1,unique,dive,min=1"` which failed on every `examples/*` directory because example modules typically have no `variables.tf` — they drive the parent module via locals or hardcoded values. A data-driven `desired_order = [for v in data.variable.for_sort.variables : "variable.${v.name}"]` resolving to `[]` is a perfectly meaningful "no preferred ordering, leave whatever's here alone", not a configuration error.

- Validator relaxed to `unique,dive,min=1`. Duplicate and empty-string addresses still rejected (covered by existing `duplicate_address_returns_error` and `empty_address_returns_error` tests via `unique` and `min` substrings).
- `Apply()` early-returns `nil` on an empty list.
- `TestSortBlocksInFile_EmptyDesiredOrderIsError` inverted into `_IsNoOp`.

### 2. `fix(reorder_attributes): keep adjacent same-name nested blocks adjacent` (`23677e4`)

`emitReorderElements` unconditionally inserted a blank line before every nested block, which broke the common case of multiple sibling blocks of the same kind under a single block — two `validation {}` siblings under a `variable`, two `dynamic "subnet"` under a `resource`, etc. Real-world Terraform style (and avmfix's implicit `hclwrite.Format` behaviour) keeps these grouped.

- Gates the nested-block blank-line trigger on `!prevSameKindNested` where same-kind means same orderable name (which already returns the dynamic label via `writeBlockName`).
- Section boundaries (head→middle, middle→tail) still force a blank line — that separator is requested explicitly.
- Existing `multiple_nested_blocks_each_get_leading_blank_line` test (two different-name nested blocks) continues to pass.

Six new test cases:
- adjacent `validation {}` siblings stay adjacent
- three adjacent `validation {}` siblings all stay adjacent
- adjacent `dynamic "subnet"` (same label) stay adjacent
- `dynamic "subnet"` followed by `dynamic "route"` still gets blank
- same-name nested with attr between does NOT group
- section boundary at same-name nested still inserts blank

### 3. `feat(normalize_whitespace): make adjacent same-kind block grouping opt-in` (`5d1935c`)

Adds a new opt-in behaviour to the post-save normalizer: when enabled, adjacent root-level **unlabeled** same-kind blocks (e.g. two `locals {}` or two `moved {}` blocks) stay on directly consecutive lines with no blank line between them. **Labeled** blocks (`variable`, `output`, `resource`, `module`, etc.) always get a blank line between siblings regardless of the setting, because each represents a distinct named entity.

**Off by default.** v0.1.1's "exactly one blank line between every pair of root blocks" remains the default behaviour. Consumers who want avmfix-style adjacent-locals grouping pass `--keep-adjacent-blocks` to `mapotf transform`. Rationale: visual separation between sibling `moved {}` blocks is meaningful — each is an individually-reviewable refactoring record — and consumers should opt into collapsing them rather than have it imposed.

Implementation:
- New `terraform.NormalizeOptions{KeepAdjacentSameKindUnlabeledBlocks bool}` carries the setting.
- `terraform.SetNormalizeOptions(opts)` lets the CLI layer set the package-level default once at startup. Package-level state is acceptable here because mapotf is a single-shot CLI process.
- `transform` subcommand gains `--keep-adjacent-blocks` (default `false`).
- Same-kind detection uses HCL token inspection: the previous block's `TokenIdent` is followed by `TokenOBrace` (unlabeled) and the next block's `TokenIdent` matches.
- Comments at depth 0 between blocks always break adjacency.

Tests:
- `TestNormalizeFileWhitespace` (default mode) — 8 new cases pinning the "always blank" default: adjacent locals/moved/labeled siblings all get blank line.
- `TestNormalizeFileWhitespace_KeepAdjacentSameKindUnlabeledBlocks` (opt-in mode) — 11 cases covering the grouping behaviour: two and three adjacent locals/moved; comments forcing blanks; labeled siblings unaffected; existing blanks between same-kind unlabeled collapse away.
- `TestNormalizeFileWhitespace_DefaultMatchesZeroOptions` — pins the zero-value contract.
- `TestNormalizeFileWhitespace_SetNormalizeOptionsRoundtrip` — verifies the setter restores correctly.
- `TestNormalizeFileWhitespace_Idempotent_KeepAdjacent` — opt-in mode is idempotent.

## Verification

- `go test ./... -count=1` — all 4 packages pass.
- `golangci-lint v2.4.0` — 0 issues.
- The governance migration session has verified the underlying fixes (#1 unblocks `examples/*` dirs, #2 collapses the residual `variables.tf` mid-file blank in `validation`-heavy modules). Once v0.1.2 ships, governance will re-verify against the default-off normalizer and decide separately whether they want to pass `--keep-adjacent-blocks` to get avmfix-style adjacent-locals.

## Note on the branch name

The branch was originally named for the v0.1.1 work but PR #96 merged first. These three commits are sequenced on top of v0.1.1; the next tag will be v0.1.2.
