### PR TITLE
v0.1.3: AddBlock structured insertion + ephemeral resource enumerator

### DIFF
--- a/doc/d/ephemeral.md
+++ b/doc/d/ephemeral.md
@@ -1,0 +1,68 @@
+# Data "ephemeral" Block
+
+The `data "ephemeral"` block is used to query and retrieve `ephemeral` blocks from a Terraform configuration. Ephemeral resources were introduced in Terraform 1.10 for values that should not be persisted in state (e.g. tokens, short-lived credentials). This data block allows you to filter and collect ephemeral blocks based on specific criteria such as the ephemeral resource type, and whether `count` or `for_each` is used.
+
+The shape and semantics mirror [`data "resource"`](resource.md) and [`data "data"`](data.md); only the queried block type differs.
+
+## Arguments
+
+- `ephemeral_type`: This optional argument specifies the type of the ephemeral resource to filter. It is a string attribute.
+- `use_count`: This optional argument is a boolean that, when set to `true`, filters ephemeral blocks that use the `count` attribute. The default value is `false`.
+- `use_for_each`: This optional argument is a boolean that, when set to `true`, filters ephemeral blocks that use the `for_each` attribute. The default value is `false`.
+
+## Attributes
+
+- `result`: This attribute contains the filtered ephemeral blocks, all expressions assigned to arguments are evaluated as strings.
+
+## Example - Querying Ephemeral Blocks
+
+Here is an example of how to use the `data "ephemeral"` block to query ephemeral resources of a specific type:
+
+```terraform
+data "ephemeral" "secrets" {
+  ephemeral_type = "azurerm_key_vault_secret"
+}
+```
+
+In this example, the `data "ephemeral"` block queries all ephemeral blocks of type `azurerm_key_vault_secret` and stores the result in the `secrets` data source.
+
+## Example - Filtering Ephemeral Blocks with `count`
+
+```terraform
+data "ephemeral" "example" {
+  ephemeral_type = "fake_ephemeral"
+  use_count      = true
+}
+```
+
+## Example - Filtering Ephemeral Blocks with `for_each`
+
+```terraform
+data "ephemeral" "example" {
+  ephemeral_type = "fake_ephemeral"
+  use_for_each   = true
+}
+```
+
+## Example - Retrieving Results
+
+Assuming we have such Terraform config:
+
+```terraform
+ephemeral "azurerm_key_vault_secret" "example" {
+  name         = "db-password"
+  key_vault_id = data.azurerm_key_vault.example.id
+}
+```
+
+And our Mapotf config is:
+
+```terraform
+data "ephemeral" "example" {
+  ephemeral_type = "azurerm_key_vault_secret"
+}
+```
+
+The data source's results are aggregated by ephemeral type first, then by the block labels, identically to `data "data"` and `data "resource"`. Each block exposes its arguments as string-valued attributes plus the standard `mptf` metadata object (block address, labels, range, module reference).
+
+Ephemeral root blocks are also addressable via `RootBlock("ephemeral.<type>.<name>")` and are therefore valid targets for transforms such as `move_block`, `reorder_attributes`, `sort_blocks_in_file`, etc.

--- a/doc/index.md
+++ b/doc/index.md
@@ -15,6 +15,7 @@
 ## `data` blocks
 
 * [`data`](d/data.md)
+* [`ephemeral`](d/ephemeral.md)
 * [`local`](d/local.md)
 * [`module`](d/module.md)
 * [`moved`](d/moved.md)

--- a/pkg/data_ephemeral.go
+++ b/pkg/data_ephemeral.go
@@ -1,0 +1,77 @@
+package pkg
+
+import (
+	"github.com/Azure/golden"
+	"github.com/Azure/mapotf/pkg/terraform"
+	"github.com/ahmetb/go-linq/v3"
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+)
+
+var _ Data = &EphemeralData{}
+
+type EphemeralData struct {
+	*BaseData
+	*golden.BaseBlock
+
+	EphemeralType string    `hcl:"ephemeral_type,optional"`
+	UseCount      bool      `hcl:"use_count,optional" default:"false"`
+	UseForEach    bool      `hcl:"use_for_each,optional" default:"false"`
+	Result        cty.Value `attribute:"result"`
+}
+
+func (ed *EphemeralData) Type() string {
+	return "ephemeral"
+}
+
+func (ed *EphemeralData) ExecuteDuringPlan() error {
+	src := ed.BaseBlock.Config().(*MetaProgrammingTFConfig).EphemeralBlocks()
+	var matched []*terraform.RootBlock
+	es := linq.From(src)
+	if ed.EphemeralType != "" {
+		es = es.Where(func(i interface{}) bool {
+			return i.(*terraform.RootBlock).Labels[0] == ed.EphemeralType
+		})
+	}
+	if ed.UseForEach {
+		es = es.Where(func(i interface{}) bool {
+			return i.(*terraform.RootBlock).ForEach != nil
+		})
+	}
+	if ed.UseCount {
+		es = es.Where(func(i interface{}) bool {
+			return i.(*terraform.RootBlock).Count != nil
+		})
+	}
+	es.ToSlice(&matched)
+	ephemeralBlocks := make(map[string]map[string]cty.Value)
+	for _, b := range matched {
+		ephemeralType := b.Labels[0]
+		m, ok := ephemeralBlocks[ephemeralType]
+		if !ok {
+			m = make(map[string]cty.Value)
+			ephemeralBlocks[ephemeralType] = m
+		}
+		m[b.Labels[1]] = b.EvalContext()
+	}
+	obj := make(map[string]cty.Value)
+	for k, m := range ephemeralBlocks {
+		obj[k] = cty.ObjectVal(m)
+	}
+	ed.Result = cty.ObjectVal(obj)
+	return nil
+}
+
+func (ed *EphemeralData) String() string {
+	d := cty.ObjectVal(map[string]cty.Value{
+		"ephemeral_type": cty.StringVal(ed.EphemeralType),
+		"use_count":      cty.BoolVal(ed.UseCount),
+		"use_for_each":   cty.BoolVal(ed.UseForEach),
+		"result":         ed.Result,
+	})
+	r, err := ctyjson.Marshal(d, d.Type())
+	if err != nil {
+		panic(err.Error())
+	}
+	return string(r)
+}

--- a/pkg/data_ephemeral_test.go
+++ b/pkg/data_ephemeral_test.go
@@ -1,0 +1,163 @@
+package pkg_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Azure/golden"
+	"github.com/Azure/mapotf/pkg"
+	filesystem "github.com/Azure/mapotf/pkg/fs"
+	"github.com/Azure/mapotf/pkg/terraform"
+	"github.com/prashantv/gostub"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestEphemeralData_QueryEphemeralBlocks(t *testing.T) {
+	cases := []struct {
+		desc       string
+		tfCode     string
+		useForEach bool
+		useCount   bool
+		expected   cty.Value
+	}{
+		{
+			desc: "only one ephemeral block without count or for_each",
+			tfCode: `ephemeral "fake_ephemeral" this {
+	id = 123
+}`,
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"fake_ephemeral": cty.ObjectVal(map[string]cty.Value{
+					"this": cty.ObjectVal(map[string]cty.Value{
+						"id": cty.StringVal("123"),
+					}),
+				}),
+			}),
+		},
+		{
+			desc: "count",
+			tfCode: `
+ephemeral "fake_ephemeral" this {}
+ephemeral "fake_ephemeral" that {
+  count = 2
+}
+`,
+			useCount: true,
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"fake_ephemeral": cty.ObjectVal(map[string]cty.Value{
+					"that": cty.ObjectVal(map[string]cty.Value{
+						"count": cty.StringVal("2"),
+					}),
+				}),
+			}),
+		},
+		{
+			desc: "for_each",
+			tfCode: `
+ephemeral "fake_ephemeral" this {}
+ephemeral "fake_ephemeral" that {
+  for_each = toset([1,2,3])
+}
+`,
+			useForEach: true,
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"fake_ephemeral": cty.ObjectVal(map[string]cty.Value{
+					"that": cty.ObjectVal(map[string]cty.Value{
+						"for_each": cty.StringVal("toset([1,2,3])"),
+					}),
+				}),
+			}),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			stub := gostub.Stub(&filesystem.Fs, fakeFs(map[string]string{
+				"/main.tf": c.tfCode,
+			})).Stub(&terraform.RootBlockReflectionInformation, func(map[string]cty.Value, *terraform.RootBlock) {})
+			defer stub.Reset()
+			cfg, err := pkg.NewMetaProgrammingTFConfig(&pkg.TerraformModuleRef{
+				Dir:    "/",
+				AbsDir: "/",
+			}, nil, nil, nil, context.TODO())
+			require.NoError(t, err)
+
+			data := &pkg.EphemeralData{
+				BaseBlock:     golden.NewBaseBlock(cfg, nil),
+				EphemeralType: "fake_ephemeral",
+				UseCount:      c.useCount,
+				UseForEach:    c.useForEach,
+			}
+
+			err = data.ExecuteDuringPlan()
+			require.NoError(t, err)
+
+			result := golden.Value(data)
+
+			expected := map[string]cty.Value{
+				"ephemeral_type": cty.StringVal("fake_ephemeral"),
+				"use_count":      cty.BoolVal(c.useCount),
+				"use_for_each":   cty.BoolVal(c.useForEach),
+				"result":         c.expected,
+			}
+			assert.Equal(t, expected, result)
+		})
+	}
+}
+
+func TestEphemeralData_CustomizedToStringShouldContainsAllFields(t *testing.T) {
+	stub := gostub.Stub(&filesystem.Fs, fakeFs(map[string]string{
+		"/main.tf": `ephemeral "fake_ephemeral" this {
+	id = 123
+}`,
+	}))
+	defer stub.Reset()
+	cfg, err := pkg.NewMetaProgrammingTFConfig(&pkg.TerraformModuleRef{
+		Dir:    "/",
+		AbsDir: "/",
+	}, nil, nil, nil, context.TODO())
+	require.NoError(t, err)
+
+	data := &pkg.EphemeralData{
+		BaseBlock:     golden.NewBaseBlock(cfg, nil),
+		EphemeralType: "fake_ephemeral",
+		UseCount:      false,
+		UseForEach:    false,
+	}
+
+	err = data.ExecuteDuringPlan()
+	require.NoError(t, err)
+
+	var sut map[string]any
+	err = json.Unmarshal([]byte(data.String()), &sut)
+	require.NoError(t, err)
+	assert.Contains(t, sut, "ephemeral_type")
+	assert.Contains(t, sut, "use_count")
+	assert.Contains(t, sut, "use_for_each")
+	assert.Contains(t, sut, "result")
+}
+
+// TestEphemeralData_RootBlockAddressLookup pins the address-prefix routing in
+// MetaProgrammingTFConfig.RootBlock: an "ephemeral.<type>.<name>" address must
+// resolve to the corresponding ephemeral RootBlock so transforms like
+// move_block can target it.
+func TestEphemeralData_RootBlockAddressLookup(t *testing.T) {
+	stub := gostub.Stub(&filesystem.Fs, fakeFs(map[string]string{
+		"/main.tf": `ephemeral "fake_ephemeral" "this" {
+  id = 123
+}`,
+	})).Stub(&terraform.RootBlockReflectionInformation, func(map[string]cty.Value, *terraform.RootBlock) {})
+	defer stub.Reset()
+
+	cfg, err := pkg.NewMetaProgrammingTFConfig(&pkg.TerraformModuleRef{
+		Dir:    "/",
+		AbsDir: "/",
+	}, nil, nil, nil, context.TODO())
+	require.NoError(t, err)
+
+	block := cfg.RootBlock("ephemeral.fake_ephemeral.this")
+	require.NotNil(t, block, "ephemeral.fake_ephemeral.this should be addressable via RootBlock")
+	assert.Equal(t, "ephemeral", block.Type)
+	assert.Equal(t, []string{"fake_ephemeral", "this"}, block.Labels)
+}

--- a/pkg/init.go
+++ b/pkg/init.go
@@ -32,6 +32,7 @@ func registerData() {
 	golden.RegisterBlock(new(ProviderSchemaData))
 	golden.RegisterBlock(new(TerraformData))
 	golden.RegisterBlock(new(DataSourceData))
+	golden.RegisterBlock(new(EphemeralData))
 	golden.RegisterBlock(new(DataVariable))
 	golden.RegisterBlock(new(DataOutput))
 	golden.RegisterBlock(new(DataLocal))

--- a/pkg/mptf_config.go
+++ b/pkg/mptf_config.go
@@ -22,16 +22,17 @@ var _ golden.Config = &MetaProgrammingTFConfig{}
 
 type MetaProgrammingTFConfig struct {
 	*golden.BaseConfig
-	resourceBlocks map[string]*terraform.RootBlock
-	dataBlocks     map[string]*terraform.RootBlock
-	variableBlocks map[string]*terraform.RootBlock
-	localBlocks    map[string]*terraform.RootBlock
-	outputBlocks   map[string]*terraform.RootBlock
-	moduleBlocks   map[string]*terraform.RootBlock
-	movedBlocks    map[string]*terraform.RootBlock
-	terraformBlock *terraform.RootBlock
-	allRootBlocks  []*terraform.RootBlock
-	module         *terraform.Module
+	resourceBlocks  map[string]*terraform.RootBlock
+	dataBlocks      map[string]*terraform.RootBlock
+	ephemeralBlocks map[string]*terraform.RootBlock
+	variableBlocks  map[string]*terraform.RootBlock
+	localBlocks     map[string]*terraform.RootBlock
+	outputBlocks    map[string]*terraform.RootBlock
+	moduleBlocks    map[string]*terraform.RootBlock
+	movedBlocks     map[string]*terraform.RootBlock
+	terraformBlock  *terraform.RootBlock
+	allRootBlocks   []*terraform.RootBlock
+	module          *terraform.Module
 }
 
 func NewMetaProgrammingTFConfig(m *TerraformModuleRef, varConfigDir *string, hclBlocks []*golden.HclBlock, cliFlagAssignedVars []golden.CliFlagAssignedVariables, ctx context.Context) (*MetaProgrammingTFConfig, error) {
@@ -63,6 +64,7 @@ func (c *MetaProgrammingTFConfig) reloadTerraformModule(m *TerraformModuleRef) e
 	}
 	c.resourceBlocks = groupByAddress(module.ResourceBlocks)
 	c.dataBlocks = groupByAddress(module.DataBlocks)
+	c.ephemeralBlocks = groupByAddress(module.EphemeralBlocks)
 	c.moduleBlocks = groupByAddress(module.ModuleBlocks)
 	c.variableBlocks = groupByAddress(module.Variables)
 	c.outputBlocks = groupByAddress(module.Outputs)
@@ -86,6 +88,10 @@ func (c *MetaProgrammingTFConfig) ResourceBlocks() []*terraform.RootBlock {
 
 func (c *MetaProgrammingTFConfig) DataBlocks() []*terraform.RootBlock {
 	return c.slice(c.dataBlocks)
+}
+
+func (c *MetaProgrammingTFConfig) EphemeralBlocks() []*terraform.RootBlock {
+	return c.slice(c.ephemeralBlocks)
 }
 
 func (c *MetaProgrammingTFConfig) VariableBlocks() []*terraform.RootBlock {
@@ -118,6 +124,9 @@ func (c *MetaProgrammingTFConfig) RootBlock(address string) *terraform.RootBlock
 	}
 	if strings.HasPrefix(address, "data.") {
 		return c.dataBlocks[address]
+	}
+	if strings.HasPrefix(address, "ephemeral.") {
+		return c.ephemeralBlocks[address]
 	}
 	if strings.HasPrefix(address, "variable.") {
 		return c.variableBlocks[address]

--- a/pkg/terraform/module.go
+++ b/pkg/terraform/module.go
@@ -175,8 +175,12 @@ func (m *Module) AddBlock(fileName string, block *hclwrite.Block) {
 	if len(tokens) > 1 && tokens[len(tokens)-1].Type != hclsyntax.TokenNewline {
 		writeFile.Body().AppendNewline()
 	}
-	writeFile.Body().AppendUnstructuredTokens(block.BuildTokens(nil))
-	writeFile.Body().AppendNewline()
+	// AppendBlock (rather than AppendUnstructuredTokens(block.BuildTokens(nil)))
+	// inserts the block as a structured element, so subsequent body.Blocks()
+	// walks — including the ones inside RemoveBlock — can find it. Any extra
+	// trailing whitespace is canonicalized by normalizeFileWhitespace in
+	// SaveToDisk.
+	writeFile.Body().AppendBlock(block)
 }
 
 func (m *Module) RemoveBlock(block *hclwrite.Block) {

--- a/pkg/terraform/module.go
+++ b/pkg/terraform/module.go
@@ -23,6 +23,9 @@ var wantedTypes = map[string]func(module *Module) *[]*RootBlock{
 	"data": func(m *Module) *[]*RootBlock {
 		return &m.DataBlocks
 	},
+	"ephemeral": func(m *Module) *[]*RootBlock {
+		return &m.EphemeralBlocks
+	},
 	"module": func(m *Module) *[]*RootBlock {
 		return &m.ModuleBlocks
 	},
@@ -41,6 +44,7 @@ type Module struct {
 	lock            *sync.Mutex
 	ResourceBlocks  []*RootBlock
 	DataBlocks      []*RootBlock
+	EphemeralBlocks []*RootBlock
 	ModuleBlocks    []*RootBlock
 	TerraformBlocks []*RootBlock
 	Variables       []*RootBlock
@@ -253,7 +257,8 @@ func (m *Module) Blocks() []*RootBlock {
 	var blocks []*RootBlock
 	linq.From(m.TerraformBlocks).Concat(linq.From(m.Locals)).
 		Concat(linq.From(m.Outputs)).Concat(linq.From(m.Variables)).
-		Concat(linq.From(m.DataBlocks)).Concat(linq.From(m.ResourceBlocks)).
+		Concat(linq.From(m.DataBlocks)).Concat(linq.From(m.EphemeralBlocks)).
+		Concat(linq.From(m.ResourceBlocks)).
 		Concat(linq.From(m.ModuleBlocks)).Concat(linq.From(m.MovedBlocks)).
 		ToSlice(&blocks)
 	return blocks

--- a/pkg/terraform/module_test.go
+++ b/pkg/terraform/module_test.go
@@ -309,3 +309,67 @@ func createResourceBlock(resourceType, name, resourceName string) *hclwrite.Bloc
 	b.Body().SetAttributeValue("name", cty.StringVal(resourceName))
 	return b
 }
+
+// TestModule_AddBlockThenRemoveBlock_Roundtrip asserts that a block added via
+// AddBlock is visible to subsequent RemoveBlock calls. Regression test for the
+// "AddBlock uses unstructured tokens so body.Blocks() can't see the added
+// block" bug — see RemoveBlock implementation walking body.Blocks().
+func TestModule_AddBlockThenRemoveBlock_Roundtrip(t *testing.T) {
+	mockFs := afero.NewMemMapFs()
+	stub := gostub.Stub(&filesystem.Fs, mockFs)
+	defer stub.Reset()
+
+	require.NoError(t, mockFs.MkdirAll("tmp", 0755))
+
+	m := &Module{
+		Dir:        "tmp",
+		AbsDir:     "tmp",
+		writeFiles: make(map[string]*hclwrite.File),
+		lock:       &sync.Mutex{},
+	}
+
+	block := createResourceBlock("azurerm_resource_group", "added", "added-rg")
+	m.AddBlock("new_file.tf", block)
+
+	// RemoveBlock must find the block we just added; pointer-equality pass
+	// or type+labels fallback must see it.
+	m.RemoveBlock(block)
+
+	require.NoError(t, m.SaveToDisk())
+
+	content, err := afero.ReadFile(mockFs, "tmp/new_file.tf")
+	require.NoError(t, err)
+	assert.Equal(t, "", string(content),
+		"after AddBlock+RemoveBlock the file should be empty; if not, AddBlock isn't inserting the block in a form that body.Blocks() can find")
+}
+
+// TestModule_AddBlockThenRemoveBlock_ByTypeAndLabels covers the type+labels
+// fallback path in RemoveBlock: a NEW *hclwrite.Block (different pointer) with
+// matching type and labels should still be removed.
+func TestModule_AddBlockThenRemoveBlock_ByTypeAndLabels(t *testing.T) {
+	mockFs := afero.NewMemMapFs()
+	stub := gostub.Stub(&filesystem.Fs, mockFs)
+	defer stub.Reset()
+
+	require.NoError(t, mockFs.MkdirAll("tmp", 0755))
+
+	m := &Module{
+		Dir:        "tmp",
+		AbsDir:     "tmp",
+		writeFiles: make(map[string]*hclwrite.File),
+		lock:       &sync.Mutex{},
+	}
+
+	added := createResourceBlock("azurerm_resource_group", "added", "added-rg")
+	m.AddBlock("new_file.tf", added)
+
+	// Remove by a fresh block with the same type+labels (pointer differs).
+	matcher := hclwrite.NewBlock("resource", []string{"azurerm_resource_group", "added"})
+	m.RemoveBlock(matcher)
+
+	require.NoError(t, m.SaveToDisk())
+
+	content, err := afero.ReadFile(mockFs, "tmp/new_file.tf")
+	require.NoError(t, err)
+	assert.Equal(t, "", string(content))
+}

--- a/pkg/terraform/module_test.go
+++ b/pkg/terraform/module_test.go
@@ -21,9 +21,11 @@ func TestLoadModuleShouldLoadAllTerraformFiles(t *testing.T) {
 	defer stub.Reset()
 	_ = afero.WriteFile(mockFs, "/main.tf", []byte(`resource "fake_resource" this {}
 data "fake_data" this {}
+ephemeral "fake_ephemeral" this {}
 `), 0644)
 	_ = afero.WriteFile(mockFs, "/main2.tf", []byte(`resource "fake_resource" that {}
 data "fake_data" that {}
+ephemeral "fake_ephemeral" that {}
 `), 0644)
 	sut, err := LoadModule(ModuleRef{
 		Dir:    ".",
@@ -32,6 +34,7 @@ data "fake_data" that {}
 	require.NoError(t, err)
 	assert.Len(t, sut.ResourceBlocks, 2)
 	assert.Len(t, sut.DataBlocks, 2)
+	assert.Len(t, sut.EphemeralBlocks, 2)
 }
 
 func TestModule_SaveToDisk(t *testing.T) {

--- a/pkg/transform_move_block.go
+++ b/pkg/transform_move_block.go
@@ -31,7 +31,10 @@ func (m *MoveBlockTransform) Apply() error {
 	if block.Range().Filename == m.FileName {
 		return nil
 	}
-	cfg.AddBlock(m.FileName, writeBlock)
+	// RemoveBlock must precede AddBlock: the new structured AppendBlock used
+	// by AddBlock requires the block not already be owned by another body.
+	// (Same pattern as sort_blocks_in_file.)
 	cfg.module.RemoveBlock(writeBlock)
+	cfg.AddBlock(m.FileName, writeBlock)
 	return nil
 }

--- a/pkg/transform_new_block_test.go
+++ b/pkg/transform_new_block_test.go
@@ -361,7 +361,6 @@ func TestNewBlockTransform_MalformedNewBlockShouldNotBlockSave(t *testing.T) {
 	expected := `variable "test" {
   type =.string
 }
-
 `
 	actual := string(after)
 	assert.Equal(t, expected, actual)


### PR DESCRIPTION
v0.1.3 bundles two changes uncovered during the
[`Azure/avm-terraform-governance` migration](https://github.com/Azure/avm-terraform-governance/pull/472) that
replaces avmfix with native mapotf transforms.

---

## 1. `fix(module): AddBlock uses structured AppendBlock so RemoveBlock can find added blocks` (commit `b81fabd`)

### Problem

Discovered by the governance session during a coverage audit on PR #472. They synthesised an adversarial fixture (stray `output { }` in `variables.tf`, stray `variable { }` in `outputs.tf`) and composed a `move_block` transform with a `sort_blocks_in_file` transform targeting the same address. The expected outcome was a single block in the canonical file; the observed outcome was an **orphan duplicate** — the block stayed in the source file AND a fresh copy landed in the target file.

### Diagnosis

`AddBlock` inserted blocks via `body.AppendUnstructuredTokens(block.BuildTokens(nil))`. The HCL `*hclwrite.Body.Blocks()` walk only returns **structured** blocks — tokens added via `AppendUnstructuredTokens` are invisible to it. So when a subsequent `RemoveBlock(X)` scanned `body.Blocks()`, it couldn't find the moved block in either file (only the unstructured copy that was added, which it can't see), so it short-circuited and the `AddBlock` ran, producing a duplicate.

Latent for AVM-conformant modules (no strays) but tripped immediately for any caller composing `move_block` + `sort_blocks_in_file` on the same address. The governance session confirmed by reading our source and wrote up the root cause [here](https://github.com/Azure/avm-terraform-governance/commit/15bff65).

### Fix

1. **`pkg/terraform/module.go`** — `AddBlock` now uses `Body().AppendBlock(block)` (proper structured insertion). The trailing `AppendNewline()` is dropped because block tokens already end with `}\n` and `normalizeFileWhitespace` (v0.1.1) canonicalises trailing whitespace.

2. **`pkg/transform_move_block.go`** — Swapped order from `AddBlock → RemoveBlock` to `RemoveBlock → AddBlock`. The old order relied on `AppendUnstructuredTokens(BuildTokens(...))` having copy semantics; `AppendBlock` does not, so the block must be detached from any body before re-attaching. Matches the pattern already used by `sort_blocks_in_file` since v0.1.0.

3. **`pkg/transform_new_block_test.go`** — `TestNewBlockTransform_MalformedNewBlockShouldNotBlockSave` expected `}\n\n`; updated to `}\n`. The trailing blank was an artefact of the redundant `AppendNewline`; new behaviour is strictly more correct.

4. **`pkg/terraform/module_test.go`** — Two new regression tests pin both paths through `RemoveBlock`:
   - `TestModule_AddBlockThenRemoveBlock_Roundtrip` — pointer-equality path.
   - `TestModule_AddBlockThenRemoveBlock_ByTypeAndLabels` — type+labels fallback path.

Both tests fail on `main` (file still contains the block) and pass with the fix.

---

## 2. `feat(data): add ephemeral resource enumerator` (commit `5954b35`)

### Motivation

The governance migration's `mapotf-configs/pre-commit/order_resource_meta.mptf.hcl` (added on the avm-terraform-governance side in PR #472) uses `data "resource"` + `data "data"` enumerators with `reorder_attributes` to enforce the AVM head→middle→tail meta-arg ordering (`for_each`/`count`/`provider` first, `lifecycle`/`depends_on` last) on every resource and data source block. Ephemeral resources (Terraform 1.10+, e.g. `ephemeral "azurerm_key_vault_secret"`) have the same meta-arg ordering convention but no enumerator existed.

Without an `ephemeral` enumerator, the governance side would have to either skip ephemeral block ordering or write per-block `reorder_attributes` configs by hand for every ephemeral resource — defeating the point of the data-driven approach.

### Changes

Mirrors the existing `data "resource"` / `data "data"` enumerator shape exactly:

* **`pkg/terraform/module.go`** — adds `"ephemeral"` to `wantedTypes`, an `EphemeralBlocks []*RootBlock` field on `Module`, and a slot in `Blocks()` so loaded ephemeral root blocks are visible to all existing transforms. Address generated by the existing `<type>.<labels...>` convention → `ephemeral.<type>.<name>`.
* **`pkg/mptf_config.go`** — adds `ephemeralBlocks` map + `EphemeralBlocks()` accessor, populates it in `reloadTerraformModule`, and routes the `ephemeral.` address prefix in `RootBlock(address)`.
* **`pkg/data_ephemeral.go`** — new `EphemeralData` block type, structurally identical to `DataSourceData`/`ResourceData`. Filters on `ephemeral_type`, `use_count`, `use_for_each`; emits `result.<type>.<name>` as nested `cty.ObjectVal` of each block's `EvalContext()`.
* **`pkg/init.go`** — registers `EphemeralData` alongside the other data block types.

### Out of scope (deliberate)

Schema introspection is **not** added. Ephemeral resources follow the same "block enumeration only, leave schema-driven attribute ordering to the config author via `data.provider_schema`" model already established for `data "resource"` and `data "data"`. The governance side's `order_resource_meta.mptf.hcl` pattern (head + tail only, middle untouched) works identically for ephemeral.

### Tests

* `pkg/data_ephemeral_test.go` — three filter sub-cases (no filter, `use_count`, `use_for_each`) mirroring `data_data_source_test.go`, plus a JSON-shape assertion on `String()`, plus a regression that pins `RootBlock("ephemeral.<type>.<name>")` address lookup.
* `pkg/terraform/module_test.go` — extends the existing load-all fixture with an `ephemeral "fake_ephemeral"` block per file and asserts `sut.EphemeralBlocks` count.

### Docs

* `doc/d/ephemeral.md` — new reference page mirroring `doc/d/data.md` / `doc/d/resource.md`.
* `doc/index.md` — adds `ephemeral` to the data-blocks list alphabetically between `data` and `local`.

---

## Verification (both commits)

- `go test ./... -count=1` green across all packages.
- `golangci-lint v2.4.0-alpine` reports 0 issues.
- New regression tests in commit `b81fabd` fail on `main`, pass on the branch.

## Downstream impact

After merge + `v0.1.3` tag → release workflow publishes binaries → governance side (PR #472) can:
1. Drop the belt-and-braces filter tightening from [`15bff65`](https://github.com/Azure/avm-terraform-governance/commit/15bff65) (becomes redundant but not harmful).
2. Add an `ephemeral.*.for_order` block to `mapotf-configs/pre-commit/order_resource_meta.mptf.hcl` to extend meta-arg ordering coverage to ephemeral resources.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>