### PR TITLE
v0.1.3: AddBlock fix + ephemeral enumerator + schema-driven body ordering + head/body/foot rename

### DIFF
--- a/doc/d/ephemeral.md
+++ b/doc/d/ephemeral.md
@@ -1,0 +1,68 @@
+# Data "ephemeral" Block
+
+The `data "ephemeral"` block is used to query and retrieve `ephemeral` blocks from a Terraform configuration. Ephemeral resources were introduced in Terraform 1.10 for values that should not be persisted in state (e.g. tokens, short-lived credentials). This data block allows you to filter and collect ephemeral blocks based on specific criteria such as the ephemeral resource type, and whether `count` or `for_each` is used.
+
+The shape and semantics mirror [`data "resource"`](resource.md) and [`data "data"`](data.md); only the queried block type differs.
+
+## Arguments
+
+- `ephemeral_type`: This optional argument specifies the type of the ephemeral resource to filter. It is a string attribute.
+- `use_count`: This optional argument is a boolean that, when set to `true`, filters ephemeral blocks that use the `count` attribute. The default value is `false`.
+- `use_for_each`: This optional argument is a boolean that, when set to `true`, filters ephemeral blocks that use the `for_each` attribute. The default value is `false`.
+
+## Attributes
+
+- `result`: This attribute contains the filtered ephemeral blocks, all expressions assigned to arguments are evaluated as strings.
+
+## Example - Querying Ephemeral Blocks
+
+Here is an example of how to use the `data "ephemeral"` block to query ephemeral resources of a specific type:
+
+```terraform
+data "ephemeral" "secrets" {
+  ephemeral_type = "azurerm_key_vault_secret"
+}
+```
+
+In this example, the `data "ephemeral"` block queries all ephemeral blocks of type `azurerm_key_vault_secret` and stores the result in the `secrets` data source.
+
+## Example - Filtering Ephemeral Blocks with `count`
+
+```terraform
+data "ephemeral" "example" {
+  ephemeral_type = "fake_ephemeral"
+  use_count      = true
+}
+```
+
+## Example - Filtering Ephemeral Blocks with `for_each`
+
+```terraform
+data "ephemeral" "example" {
+  ephemeral_type = "fake_ephemeral"
+  use_for_each   = true
+}
+```
+
+## Example - Retrieving Results
+
+Assuming we have such Terraform config:
+
+```terraform
+ephemeral "azurerm_key_vault_secret" "example" {
+  name         = "db-password"
+  key_vault_id = data.azurerm_key_vault.example.id
+}
+```
+
+And our Mapotf config is:
+
+```terraform
+data "ephemeral" "example" {
+  ephemeral_type = "azurerm_key_vault_secret"
+}
+```
+
+The data source's results are aggregated by ephemeral type first, then by the block labels, identically to `data "data"` and `data "resource"`. Each block exposes its arguments as string-valued attributes plus the standard `mptf` metadata object (block address, labels, range, module reference).
+
+Ephemeral root blocks are also addressable via `RootBlock("ephemeral.<type>.<name>")` and are therefore valid targets for transforms such as `move_block`, `reorder_attributes`, `sort_blocks_in_file`, etc.

--- a/doc/d/module_source.md
+++ b/doc/d/module_source.md
@@ -1,0 +1,86 @@
+# Data `"module_source"` block
+
+The `module_source` data source fetches a remote Terraform module by its `source` address (registry shortcut, Git URL, local path, etc.) and exposes the module's declared variables and outputs. The pre-sorted `required_variables` / `optional_variables` lists are intended to feed directly into `reorder_attributes.body_attributes` so every `module.<name>` call site can be re-ordered to match the source module's variable contract.
+
+## Arguments
+
+- `source` (String, Required): The module source, exactly as you would write it in a `module { source = "..." }` block — for example `Azure/naming/azurerm`, `git::https://github.com/Azure/terraform-azurerm-aks.git?ref=v9.0.0`, or `./modules/storage`.
+- `version` (String, Optional): A version constraint, only meaningful for sources that support versioning (e.g. registry sources). Same syntax as the `version` argument of a `module` block — for example `~> 0.4`.
+
+## Attributes
+
+- `variables` (Object): A map keyed by variable name. Each value is an object with:
+    - `required` (Bool): `true` when the variable has no `default` in the source module.
+    - `type` (String): The HCL type expression as written in the source module's `variable` block (for example `string`, `map(string)`, `object({ name = string })`). May be empty if the source module declares no explicit type.
+    - `description` (String): The variable's `description` attribute, or `""` if absent.
+    - `sensitive` (Bool): The variable's `sensitive` attribute, or `false` if absent.
+    - `default` (String, nullable): String rendering of the variable's `default` value, or `null` for required variables.
+- `outputs` (Object): A map keyed by output name. Each value is an object with:
+    - `description` (String)
+    - `sensitive` (Bool)
+- `required_variables` (List of String): Alphabetically-sorted list of variable names that have no `default` in the source module.
+- `optional_variables` (List of String): Alphabetically-sorted list of variable names that have a `default` in the source module.
+
+## Example - Order a module call's inputs required-then-optional
+
+```terraform
+data "module_source" "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "~> 0.4"
+}
+
+transform "reorder_attributes" "naming_module" {
+  target_block_address = "module.naming"
+  head_attributes      = ["source", "version", "providers", "for_each", "count"]
+  body_attributes = concat(
+    data.module_source.naming.required_variables,
+    data.module_source.naming.optional_variables,
+  )
+  foot_attributes = ["depends_on"]
+}
+```
+
+The body of `module "naming"` is rewritten to emit every required input first (alphabetical), followed by every optional input the call site sets (alphabetical), separated from the head and foot sections by the blank lines that `reorder_attributes` adds when `head_foot_line_breaks` is `true` (the default).
+
+Inputs the call site sets that aren't declared by the source module are not lost — they land at the end of the body, sorted alphabetically by default (or in source order if `sort_body_alphabetically = false`).
+
+## Example - Apply the same ordering to every `module` call
+
+Combine `data "module_source"` with `data "module"` and `for_each` to enforce the contract uniformly across an entire repository:
+
+```terraform
+data "module" "all" {}
+
+data "module_source" "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "~> 0.4"
+}
+
+# Look up the right module_source per module call by inspecting the
+# module block's `source` attribute. Here we keep it simple with a
+# single shared source.
+locals {
+  module_addresses = { for name, _ in data.module.all.result : name => name }
+}
+
+transform "reorder_attributes" "module_inputs" {
+  for_each             = local.module_addresses
+  target_block_address = "module.${each.key}"
+  head_attributes      = ["source", "version", "providers", "for_each", "count"]
+  body_attributes = concat(
+    data.module_source.naming.required_variables,
+    data.module_source.naming.optional_variables,
+  )
+  foot_attributes = ["depends_on"]
+}
+```
+
+For a multi-source repository, branch on `data.module.all.result[each.key].source` to pick the right `data "module_source"` block.
+
+## Under the Hood
+
+Mapotf synthesises a minimal Terraform configuration that calls the requested module in a temporary directory, runs `terraform get` to fetch the module source, then loads the fetched module with `terraform-config-inspect` to read its variable and output declarations.
+
+`terraform get` fetches the module only — it does **not** download provider plugins. This makes `data "module_source"` faster than `data "provider_schema"` and means it works without provider credentials.
+
+Each unique `(source, version)` pair is fetched at most once per `mapotf transform` run.

--- a/doc/d/provider_schema.md
+++ b/doc/d/provider_schema.md
@@ -1,8 +1,8 @@
 # Data `"provider_schema"` block
 
-The `provider_schema` data source retrieves the schema from a specified Terraform provider. This schema includes information about the provider's resources, their attributes, and nested blocks.
+The `provider_schema` data source retrieves the schema from a specified Terraform provider. This schema includes information about the provider's resources, data sources, their attributes, and nested blocks.
 
-Only resource schemas would be exported this time.
+Both resource and data source schemas are exported, and the data source additionally exposes pre-sorted required / optional attribute name lists per type, intended to feed directly into `reorder_attributes.body_attributes`.
 
 ## Example Usage
 
@@ -30,11 +30,52 @@ locals {
         - `attributes` (Map): The attributes defined at the particular level of this block.
         - `block_types` (Map): Any nested blocks within this particular block.
         - `description` (String): The description for this block and format of the description. If no kind is provided, it can be assumed to be plain text.
+- `data_sources` (Map): Same shape as `resources`, but for data source schemas.
+- `resources_required_attributes` (Map of List of String): For every resource type the provider declares, the alphabetically-sorted list of attribute names whose schema marks them `required: true`. Empty list if the resource has no required attributes.
+- `resources_optional_attributes` (Map of List of String): For every resource type, the alphabetically-sorted list of attribute names whose schema marks them `optional: true`. Includes attributes that are also `computed`; the boundary that matters for body ordering is "the user is allowed to set this value".
+- `data_sources_required_attributes` (Map of List of String): Same shape, for data source types.
+- `data_sources_optional_attributes` (Map of List of String): Same shape, for data source types.
 
 ## Schema Details
 
-The `resources` attribute contains detailed information about each resource's schema. This includes the attributes and nested blocks defined for the resource. Each attribute schema includes the type, description, and other metadata.
+The `resources` and `data_sources` attributes contain detailed information about each resource / data source's schema. This includes the attributes and nested blocks defined for them. Each attribute schema includes the type, description, and other metadata.
+
+## Example - Schema-driven body ordering with `reorder_attributes`
+
+Feed the pre-sorted required / optional name lists directly into `body_attributes` so every resource of a given type has its body emitted as `required (alphabetical) → optional (alphabetical) → anything-else (alphabetical)`:
+
+```terraform
+data "provider_schema" "azurerm" {
+  provider_source  = "hashicorp/azurerm"
+  provider_version = "~> 4.0"
+}
+
+data "resource" "all" {}
+
+locals {
+  resource_addresses = merge([
+    for t, rs in data.resource.all.result : {
+      for n, _ in rs : "resource.${t}.${n}" => t
+    }
+  ]...)
+}
+
+transform "reorder_attributes" "resource_body" {
+  for_each             = local.resource_addresses
+  target_block_address = each.key
+  head_attributes      = ["for_each", "count", "provider"]
+  body_attributes = concat(
+    try(data.provider_schema.azurerm.resources_required_attributes[each.value], []),
+    try(data.provider_schema.azurerm.resources_optional_attributes[each.value], []),
+  )
+  foot_attributes = ["lifecycle", "depends_on"]
+}
+```
+
+Each `module.<address>` value in `each.value` is the resource type (e.g. `azurerm_resource_group`), used as the map key into the schema's required / optional attribute lists. `try(..., [])` keeps the transform safe if the provider schema doesn't know about the type (for example after a provider upgrade).
+
+The same pattern works for data sources by substituting `data.data.all` and `data_sources_required_attributes` / `data_sources_optional_attributes`.
 
 ## Under the Hood
 
-Mapotf uses the Terraform provider schema to retrieve the schema for the specified provider source and version. The schema is retrieved by `terraform providers schema -json -no-color` command.
+Mapotf retrieves the schema by running `terraform init` followed by `terraform providers schema -json -no-color` in a temporary directory. The temp directory is reused across data blocks within a single `mapotf transform` run, so multiple `data "provider_schema"` blocks for the same provider source pay the init cost only once.

--- a/doc/index.md
+++ b/doc/index.md
@@ -15,6 +15,7 @@
 ## `data` blocks
 
 * [`data`](d/data.md)
+* [`ephemeral`](d/ephemeral.md)
 * [`local`](d/local.md)
 * [`module`](d/module.md)
 * [`moved`](d/moved.md)

--- a/doc/index.md
+++ b/doc/index.md
@@ -18,6 +18,7 @@
 * [`ephemeral`](d/ephemeral.md)
 * [`local`](d/local.md)
 * [`module`](d/module.md)
+* [`module_source`](d/module_source.md)
 * [`moved`](d/moved.md)
 * [`output`](d/output.md)
 * [`provider_schema`](d/provider_schema.md)

--- a/doc/t/reorder_attributes.md
+++ b/doc/t/reorder_attributes.md
@@ -38,7 +38,7 @@ This makes schema-driven ordering safe: an attribute the schema doesn't yet know
 
 Nested blocks (for example `lifecycle`, `network_interface`, or `dynamic "subnet"`) are treated exactly like attributes — list them in `head_attributes` / `body_attributes` / `foot_attributes` by their block type, or, for `dynamic` blocks, by their label (e.g. `subnet` for `dynamic "subnet" {}`).
 
-A nested block in the output always has a blank line in front of it, even when no head/foot section boundary applies, so they read naturally in Terraform style.
+A nested block in the output has a blank line in front of it when it is preceded by an attribute or a different kind of nested block, so they read naturally in Terraform style. Adjacent nested blocks of the same type (and, for `dynamic`, the same label) — for example two consecutive `validation { }` blocks under a `variable` — are kept adjacent with no blank line between them.
 
 ### Edge cases
 
@@ -155,6 +155,6 @@ The body section emits provider-required attributes first (alphabetical within t
 ## Detailed Behavior
 
 - The transform runs against the parsed HCL writer view of the block, so comments and formatting on individual attributes are preserved.
-- Nested blocks always have a blank line in front of them in the output (a section-boundary blank line counts — no extra blank line is added when one is already being emitted).
+- Nested blocks have a blank line in front of them when they are preceded by an attribute or a nested block of a different type; adjacent nested blocks of the same type (and, for `dynamic`, the same label) stay adjacent without a separating blank line. A section-boundary blank line counts — no extra blank line is added when one is already being emitted.
 - Nested blocks of the same type that appear multiple times (e.g. two `network_interface` blocks) keep their write-side order when grouped together by name.
 

--- a/doc/t/reorder_attributes.md
+++ b/doc/t/reorder_attributes.md
@@ -1,27 +1,49 @@
 # `reorder_attributes` Transform Block
 
-The `reorder_attributes` transform block re-orders the attributes **and nested blocks** inside a single root block (`resource`, `data`, `variable`, `output`, `module`, `moved` or `terraform`). It only changes layout — it never adds, removes, or mutates attribute values.
+The `reorder_attributes` transform block re-orders the attributes **and nested blocks** inside a single root block (`resource`, `data`, `ephemeral`, `variable`, `output`, `module`, `moved` or `terraform`). It only changes layout — it never adds, removes, or mutates attribute values.
 
-This transform composes with `data` blocks like `data "resource"`, `data "variable"` and `data "output"` to express AVM-style "attributes must appear in this order" rules declaratively.
+This transform composes with `data` blocks like `data "resource"`, `data "variable"`, `data "output"`, `data "provider_schema"` and `data "module_source"` to express AVM-style "attributes must appear in this order" rules declaratively.
+
+> **Breaking renames in v0.1.4** — the section names are now `head` / `body` / `foot` (mirroring HTML `thead`/`tbody`/`tfoot`). Migrate every existing transform as follows:
+>
+> | v0.1.3 name | v0.1.4 name |
+> |---|---|
+> | `tail_attributes` | `foot_attributes` |
+> | `sort_middle_alphabetically` | `sort_body_alphabetically` |
+> | `head_tail_line_breaks` | `head_foot_line_breaks` |
+>
+> There are no aliases — the old names are rejected by the HCL decoder. Pin `mapotf` to `v0.1.4` and the new config in the same commit.
 
 ## Arguments
 
 - `target_block_address`: The address of the block whose layout you want to re-order, for example `resource.azurerm_storage_account.this` or `variable.location`.
 - `head_attributes` *(optional)*: Names of elements that should appear first, in the listed order.
-- `tail_attributes` *(optional)*: Names of elements that should appear last, in the listed order.
-- `head_tail_line_breaks` *(optional, default `true`)*: When `true`, a blank line is inserted between the head section and the middle, and between the middle and the tail section. Set to `false` to suppress those blank lines.
-- `sort_middle_alphabetically` *(optional, default `true`)*: When `true`, every element that is not in `head_attributes` or `tail_attributes` is sorted alphabetically by name. Set to `false` to preserve the original source order instead.
+- `body_attributes` *(optional)*: Names of elements that should appear in the **body** section (between head and foot) in the listed order. Names not in `head_attributes` / `body_attributes` / `foot_attributes` are still emitted after the listed body names — see the interaction table below for how `sort_body_alphabetically` controls their order.
+- `foot_attributes` *(optional)*: Names of elements that should appear last, in the listed order.
+- `head_foot_line_breaks` *(optional, default `true`)*: When `true`, a blank line is inserted between the head section and the body, and between the body and the foot section. Set to `false` to suppress those blank lines.
+- `sort_body_alphabetically` *(optional, default `true`)*: Controls the order of body-section elements that are **not** listed in `body_attributes`. When `true`, those elements are sorted alphabetically by name. Set to `false` to preserve the original source order instead.
+
+### How `body_attributes` and `sort_body_alphabetically` interact
+
+| `body_attributes` | `sort_body_alphabetically` | Behaviour for the body section |
+|---|---|---|
+| unset | `true` (default) | Entire body sorted alphabetically. |
+| unset | `false` | Entire body in original source order. |
+| `[a, b, c]` | `true` | `a`, `b`, `c` first (in that order, filtered to elements actually on the block); then every other body element sorted alphabetically. |
+| `[a, b, c]` | `false` | `a`, `b`, `c` first (in that order); then every other body element in original source order. |
+
+This makes schema-driven ordering safe: an attribute the schema doesn't yet know about is never lost — it just lands after the schema-derived names, in a predictable position.
 
 ### Nested blocks are elements too
 
-Nested blocks (for example `lifecycle`, `network_interface`, or `dynamic "subnet"`) are treated exactly like attributes — list them in `head_attributes` / `tail_attributes` by their block type, or, for `dynamic` blocks, by their label (e.g. `subnet` for `dynamic "subnet" {}`).
+Nested blocks (for example `lifecycle`, `network_interface`, or `dynamic "subnet"`) are treated exactly like attributes — list them in `head_attributes` / `body_attributes` / `foot_attributes` by their block type, or, for `dynamic` blocks, by their label (e.g. `subnet` for `dynamic "subnet" {}`).
 
-A nested block in the output always has a blank line in front of it, even when no head/tail section boundary applies, so they read naturally in Terraform style.
+A nested block in the output always has a blank line in front of it, even when no head/foot section boundary applies, so they read naturally in Terraform style.
 
 ### Edge cases
 
-- Names listed in `head_attributes` / `tail_attributes` that don't exist on the block are silently skipped.
-- The same name appearing in both `head_attributes` and `tail_attributes` is a configuration error.
+- Names listed in `head_attributes` / `body_attributes` / `foot_attributes` that don't exist on the block are silently skipped.
+- The same name appearing in more than one of `head_attributes`, `body_attributes`, or `foot_attributes` is a configuration error.
 - For attributes added by an earlier transform (no source position), the source-order mode sorts them alphabetically among themselves, after every element that has a source position.
 
 ## Example - Put `type` and `description` first on every variable
@@ -57,19 +79,19 @@ variable "location" {
 }
 ```
 
-The blank line between the head (`type`, `description`) and the middle (`default`) comes from the default `head_tail_line_breaks = true`.
+The blank line between the head (`type`, `description`) and the body (`default`) comes from the default `head_foot_line_breaks = true`.
 
-## Example - Head and tail together
+## Example - Head and foot together
 
 ```terraform
 transform "reorder_attributes" "resource" {
   target_block_address = "resource.azurerm_storage_account.this"
   head_attributes      = ["name", "resource_group_name", "location"]
-  tail_attributes      = ["tags"]
+  foot_attributes      = ["tags"]
 }
 ```
 
-`name`, `resource_group_name`, `location` are emitted first (in that order); `tags` is emitted last; every other attribute is sorted alphabetically between them, separated from the head and tail by blank lines.
+`name`, `resource_group_name`, `location` are emitted first (in that order); `tags` is emitted last; every other attribute is sorted alphabetically between them, separated from the head and foot by blank lines.
 
 ## Example - Nested block addressed in `head_attributes`
 
@@ -77,11 +99,11 @@ transform "reorder_attributes" "resource" {
 transform "reorder_attributes" "vm" {
   target_block_address = "resource.azurerm_virtual_machine.this"
   head_attributes      = ["count", "for_each", "network_interface"]
-  tail_attributes      = ["lifecycle", "depends_on"]
+  foot_attributes      = ["lifecycle", "depends_on"]
 }
 ```
 
-`network_interface` is a nested block; listing its type in `head_attributes` pulls it to the top alongside `count` / `for_each`. `lifecycle` (also a nested block) goes to the tail.
+`network_interface` is a nested block; listing its type in `head_attributes` pulls it to the top alongside `count` / `for_each`. `lifecycle` (also a nested block) goes to the foot.
 
 ## Example - Disable section blanks
 
@@ -89,25 +111,46 @@ transform "reorder_attributes" "vm" {
 transform "reorder_attributes" "module" {
   target_block_address  = "module.example"
   head_attributes       = ["source", "version"]
-  tail_attributes       = ["depends_on"]
-  head_tail_line_breaks = false
+  foot_attributes       = ["depends_on"]
+  head_foot_line_breaks = false
 }
 ```
 
-The head, middle, and tail are emitted contiguously with no blank-line separators (nested blocks, if any, still get their own leading blank line).
+The head, body, and foot are emitted contiguously with no blank-line separators (nested blocks, if any, still get their own leading blank line).
 
-## Example - Preserve source order for the middle
+## Example - Preserve source order for the body
 
 ```terraform
 transform "reorder_attributes" "preserve_order" {
-  target_block_address       = "resource.azurerm_storage_account.this"
-  head_attributes            = ["name", "resource_group_name", "location"]
-  tail_attributes            = ["tags"]
-  sort_middle_alphabetically = false
+  target_block_address     = "resource.azurerm_storage_account.this"
+  head_attributes          = ["name", "resource_group_name", "location"]
+  foot_attributes          = ["tags"]
+  sort_body_alphabetically = false
 }
 ```
 
-Attributes between the head and the tail keep the order they appeared in originally instead of being sorted alphabetically.
+Attributes between the head and the foot keep the order they appeared in originally instead of being sorted alphabetically.
+
+## Example - Schema-driven body ordering with `body_attributes`
+
+```terraform
+data "provider_schema" "azurerm" {
+  provider_source  = "hashicorp/azurerm"
+  provider_version = "~> 4.0"
+}
+
+transform "reorder_attributes" "resource_group_body" {
+  target_block_address = "resource.azurerm_resource_group.this"
+  head_attributes      = ["for_each", "count", "provider"]
+  body_attributes = concat(
+    try(data.provider_schema.azurerm.resources_required_attributes["azurerm_resource_group"], []),
+    try(data.provider_schema.azurerm.resources_optional_attributes["azurerm_resource_group"], []),
+  )
+  foot_attributes = ["lifecycle", "depends_on"]
+}
+```
+
+The body section emits provider-required attributes first (alphabetical within that group), then provider-optional attributes (alphabetical within that group). Any attribute on the block that isn't in either schema list still appears in the body — after the schema-listed names, sorted alphabetically by default — so a new provider release that adds an attribute can never silently drop it from the output.
 
 ## Detailed Behavior
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/go-getter/v2 v2.2.3
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/hcl/v2 v2.24.0
+	github.com/hashicorp/terraform-config-inspect v0.0.0-20260224005459-813a97530220
 	github.com/hashicorp/terraform-exec v0.25.2
 	github.com/hashicorp/terraform-json v0.27.2
 	github.com/lonegunmanb/hclfuncs v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -184,6 +184,8 @@ github.com/hashicorp/packer-plugin-sdk v0.6.1 h1:9lpdiwwqRPVk80bX+XJul5/RrxHMXOt
 github.com/hashicorp/packer-plugin-sdk v0.6.1/go.mod h1:B6i8yIPzzFWrZW0hHdH5TLFGYlJEdgRNJnP5eXNxJU4=
 github.com/hashicorp/serf v0.10.1 h1:Z1H2J60yRKvfDYAOZLd2MU0ND4AH/WDz7xYHDWQsIPY=
 github.com/hashicorp/serf v0.10.1/go.mod h1:yL2t6BqATOLGc5HF7qbFkTfXoPIY0WZdWHfEvMqbG+4=
+github.com/hashicorp/terraform-config-inspect v0.0.0-20260224005459-813a97530220 h1:v0h6j7IMgA24b8aWG5+d6WStIP9G8e/p0DKK3Bmk7YQ=
+github.com/hashicorp/terraform-config-inspect v0.0.0-20260224005459-813a97530220/go.mod h1:Gz/z9Hbn+4KSp8A2FBtNszfLSdT2Tn/uAKGuVqqWmDI=
 github.com/hashicorp/terraform-exec v0.25.2 h1:fFLAVEtAjKdGfawGUXDnKooCnqJi+TuohT3W99AGbhk=
 github.com/hashicorp/terraform-exec v0.25.2/go.mod h1:uaQV2oqVLqM4cixJryk6qIWS1qji3GtuwPG5pjGXYfc=
 github.com/hashicorp/terraform-json v0.27.2 h1:BwGuzM6iUPqf9JYM/Z4AF1OJ5VVJEEzoKST/tRDBJKU=

--- a/pkg/data_ephemeral.go
+++ b/pkg/data_ephemeral.go
@@ -1,0 +1,77 @@
+package pkg
+
+import (
+	"github.com/Azure/golden"
+	"github.com/Azure/mapotf/pkg/terraform"
+	"github.com/ahmetb/go-linq/v3"
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+)
+
+var _ Data = &EphemeralData{}
+
+type EphemeralData struct {
+	*BaseData
+	*golden.BaseBlock
+
+	EphemeralType string    `hcl:"ephemeral_type,optional"`
+	UseCount      bool      `hcl:"use_count,optional" default:"false"`
+	UseForEach    bool      `hcl:"use_for_each,optional" default:"false"`
+	Result        cty.Value `attribute:"result"`
+}
+
+func (ed *EphemeralData) Type() string {
+	return "ephemeral"
+}
+
+func (ed *EphemeralData) ExecuteDuringPlan() error {
+	src := ed.BaseBlock.Config().(*MetaProgrammingTFConfig).EphemeralBlocks()
+	var matched []*terraform.RootBlock
+	es := linq.From(src)
+	if ed.EphemeralType != "" {
+		es = es.Where(func(i interface{}) bool {
+			return i.(*terraform.RootBlock).Labels[0] == ed.EphemeralType
+		})
+	}
+	if ed.UseForEach {
+		es = es.Where(func(i interface{}) bool {
+			return i.(*terraform.RootBlock).ForEach != nil
+		})
+	}
+	if ed.UseCount {
+		es = es.Where(func(i interface{}) bool {
+			return i.(*terraform.RootBlock).Count != nil
+		})
+	}
+	es.ToSlice(&matched)
+	ephemeralBlocks := make(map[string]map[string]cty.Value)
+	for _, b := range matched {
+		ephemeralType := b.Labels[0]
+		m, ok := ephemeralBlocks[ephemeralType]
+		if !ok {
+			m = make(map[string]cty.Value)
+			ephemeralBlocks[ephemeralType] = m
+		}
+		m[b.Labels[1]] = b.EvalContext()
+	}
+	obj := make(map[string]cty.Value)
+	for k, m := range ephemeralBlocks {
+		obj[k] = cty.ObjectVal(m)
+	}
+	ed.Result = cty.ObjectVal(obj)
+	return nil
+}
+
+func (ed *EphemeralData) String() string {
+	d := cty.ObjectVal(map[string]cty.Value{
+		"ephemeral_type": cty.StringVal(ed.EphemeralType),
+		"use_count":      cty.BoolVal(ed.UseCount),
+		"use_for_each":   cty.BoolVal(ed.UseForEach),
+		"result":         ed.Result,
+	})
+	r, err := ctyjson.Marshal(d, d.Type())
+	if err != nil {
+		panic(err.Error())
+	}
+	return string(r)
+}

--- a/pkg/data_ephemeral_test.go
+++ b/pkg/data_ephemeral_test.go
@@ -1,0 +1,163 @@
+package pkg_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Azure/golden"
+	"github.com/Azure/mapotf/pkg"
+	filesystem "github.com/Azure/mapotf/pkg/fs"
+	"github.com/Azure/mapotf/pkg/terraform"
+	"github.com/prashantv/gostub"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestEphemeralData_QueryEphemeralBlocks(t *testing.T) {
+	cases := []struct {
+		desc       string
+		tfCode     string
+		useForEach bool
+		useCount   bool
+		expected   cty.Value
+	}{
+		{
+			desc: "only one ephemeral block without count or for_each",
+			tfCode: `ephemeral "fake_ephemeral" this {
+	id = 123
+}`,
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"fake_ephemeral": cty.ObjectVal(map[string]cty.Value{
+					"this": cty.ObjectVal(map[string]cty.Value{
+						"id": cty.StringVal("123"),
+					}),
+				}),
+			}),
+		},
+		{
+			desc: "count",
+			tfCode: `
+ephemeral "fake_ephemeral" this {}
+ephemeral "fake_ephemeral" that {
+  count = 2
+}
+`,
+			useCount: true,
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"fake_ephemeral": cty.ObjectVal(map[string]cty.Value{
+					"that": cty.ObjectVal(map[string]cty.Value{
+						"count": cty.StringVal("2"),
+					}),
+				}),
+			}),
+		},
+		{
+			desc: "for_each",
+			tfCode: `
+ephemeral "fake_ephemeral" this {}
+ephemeral "fake_ephemeral" that {
+  for_each = toset([1,2,3])
+}
+`,
+			useForEach: true,
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"fake_ephemeral": cty.ObjectVal(map[string]cty.Value{
+					"that": cty.ObjectVal(map[string]cty.Value{
+						"for_each": cty.StringVal("toset([1,2,3])"),
+					}),
+				}),
+			}),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			stub := gostub.Stub(&filesystem.Fs, fakeFs(map[string]string{
+				"/main.tf": c.tfCode,
+			})).Stub(&terraform.RootBlockReflectionInformation, func(map[string]cty.Value, *terraform.RootBlock) {})
+			defer stub.Reset()
+			cfg, err := pkg.NewMetaProgrammingTFConfig(&pkg.TerraformModuleRef{
+				Dir:    "/",
+				AbsDir: "/",
+			}, nil, nil, nil, context.TODO())
+			require.NoError(t, err)
+
+			data := &pkg.EphemeralData{
+				BaseBlock:     golden.NewBaseBlock(cfg, nil),
+				EphemeralType: "fake_ephemeral",
+				UseCount:      c.useCount,
+				UseForEach:    c.useForEach,
+			}
+
+			err = data.ExecuteDuringPlan()
+			require.NoError(t, err)
+
+			result := golden.Value(data)
+
+			expected := map[string]cty.Value{
+				"ephemeral_type": cty.StringVal("fake_ephemeral"),
+				"use_count":      cty.BoolVal(c.useCount),
+				"use_for_each":   cty.BoolVal(c.useForEach),
+				"result":         c.expected,
+			}
+			assert.Equal(t, expected, result)
+		})
+	}
+}
+
+func TestEphemeralData_CustomizedToStringShouldContainsAllFields(t *testing.T) {
+	stub := gostub.Stub(&filesystem.Fs, fakeFs(map[string]string{
+		"/main.tf": `ephemeral "fake_ephemeral" this {
+	id = 123
+}`,
+	}))
+	defer stub.Reset()
+	cfg, err := pkg.NewMetaProgrammingTFConfig(&pkg.TerraformModuleRef{
+		Dir:    "/",
+		AbsDir: "/",
+	}, nil, nil, nil, context.TODO())
+	require.NoError(t, err)
+
+	data := &pkg.EphemeralData{
+		BaseBlock:     golden.NewBaseBlock(cfg, nil),
+		EphemeralType: "fake_ephemeral",
+		UseCount:      false,
+		UseForEach:    false,
+	}
+
+	err = data.ExecuteDuringPlan()
+	require.NoError(t, err)
+
+	var sut map[string]any
+	err = json.Unmarshal([]byte(data.String()), &sut)
+	require.NoError(t, err)
+	assert.Contains(t, sut, "ephemeral_type")
+	assert.Contains(t, sut, "use_count")
+	assert.Contains(t, sut, "use_for_each")
+	assert.Contains(t, sut, "result")
+}
+
+// TestEphemeralData_RootBlockAddressLookup pins the address-prefix routing in
+// MetaProgrammingTFConfig.RootBlock: an "ephemeral.<type>.<name>" address must
+// resolve to the corresponding ephemeral RootBlock so transforms like
+// move_block can target it.
+func TestEphemeralData_RootBlockAddressLookup(t *testing.T) {
+	stub := gostub.Stub(&filesystem.Fs, fakeFs(map[string]string{
+		"/main.tf": `ephemeral "fake_ephemeral" "this" {
+  id = 123
+}`,
+	})).Stub(&terraform.RootBlockReflectionInformation, func(map[string]cty.Value, *terraform.RootBlock) {})
+	defer stub.Reset()
+
+	cfg, err := pkg.NewMetaProgrammingTFConfig(&pkg.TerraformModuleRef{
+		Dir:    "/",
+		AbsDir: "/",
+	}, nil, nil, nil, context.TODO())
+	require.NoError(t, err)
+
+	block := cfg.RootBlock("ephemeral.fake_ephemeral.this")
+	require.NotNil(t, block, "ephemeral.fake_ephemeral.this should be addressable via RootBlock")
+	assert.Equal(t, "ephemeral", block.Type)
+	assert.Equal(t, []string{"fake_ephemeral", "this"}, block.Labels)
+}

--- a/pkg/data_module_source.go
+++ b/pkg/data_module_source.go
@@ -1,0 +1,134 @@
+package pkg
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/Azure/golden"
+	"github.com/hashicorp/terraform-config-inspect/tfconfig"
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+)
+
+var _ Data = &ModuleSourceData{}
+
+// ModuleSourceFetcherFactory is overridable in tests; the default returns a
+// CLI-backed fetcher that runs `terraform get` in a temp directory.
+var ModuleSourceFetcherFactory = func(ctx context.Context) TerraformModuleSourceFetcher {
+	return NewTerraformCliModuleSourceFetcher(ctx)
+}
+
+// ModuleSourceData fetches the variables and outputs of a remote Terraform
+// module (by `source` + optional `version`) using `terraform get` and exposes
+// them as cty values that downstream transforms can compose against. The
+// pre-sorted `required_variables` / `optional_variables` lists are intended to
+// be fed into `reorder_attributes.body_attributes` so a `module.<name>` block's
+// inputs end up in required-then-optional alphabetical order.
+type ModuleSourceData struct {
+	*BaseData
+	*golden.BaseBlock
+
+	Source            string    `hcl:"source"`
+	Version           string    `hcl:"version,optional"`
+	Variables         cty.Value `attribute:"variables"`
+	Outputs           cty.Value `attribute:"outputs"`
+	RequiredVariables cty.Value `attribute:"required_variables"`
+	OptionalVariables cty.Value `attribute:"optional_variables"`
+}
+
+func (d *ModuleSourceData) Type() string {
+	return "module_source"
+}
+
+func (d *ModuleSourceData) ExecuteDuringPlan() error {
+	mod, err := ModuleSourceFetcherFactory(d.Context()).Get(d.Source, d.Version)
+	if err != nil {
+		return fmt.Errorf("cannot fetch module source %q version %q: %w", d.Source, d.Version, err)
+	}
+	d.Variables = convertModuleVariables(mod.Variables)
+	d.Outputs = convertModuleOutputs(mod.Outputs)
+	d.RequiredVariables, d.OptionalVariables = partitionModuleVariableNames(mod.Variables)
+	return nil
+}
+
+func convertModuleVariables(vars map[string]*tfconfig.Variable) cty.Value {
+	if len(vars) == 0 {
+		return cty.EmptyObjectVal
+	}
+	out := make(map[string]cty.Value, len(vars))
+	for name, v := range vars {
+		var def cty.Value
+		if v.Default == nil {
+			def = cty.NullVal(cty.String)
+		} else {
+			// tfconfig.Variable.Default is interface{} approximating the
+			// configured default. Render it as a string so it's safe to
+			// expose as a string-typed cty value regardless of original type.
+			def = cty.StringVal(fmt.Sprintf("%v", v.Default))
+		}
+		out[name] = cty.ObjectVal(map[string]cty.Value{
+			"required":    cty.BoolVal(v.Required),
+			"type":        cty.StringVal(v.Type),
+			"description": cty.StringVal(v.Description),
+			"sensitive":   cty.BoolVal(v.Sensitive),
+			"default":     def,
+		})
+	}
+	return cty.ObjectVal(out)
+}
+
+func convertModuleOutputs(outs map[string]*tfconfig.Output) cty.Value {
+	if len(outs) == 0 {
+		return cty.EmptyObjectVal
+	}
+	out := make(map[string]cty.Value, len(outs))
+	for name, o := range outs {
+		out[name] = cty.ObjectVal(map[string]cty.Value{
+			"description": cty.StringVal(o.Description),
+			"sensitive":   cty.BoolVal(o.Sensitive),
+		})
+	}
+	return cty.ObjectVal(out)
+}
+
+func partitionModuleVariableNames(vars map[string]*tfconfig.Variable) (required, optional cty.Value) {
+	var req, opt []string
+	for name, v := range vars {
+		if v.Required {
+			req = append(req, name)
+		} else {
+			opt = append(opt, name)
+		}
+	}
+	sort.Strings(req)
+	sort.Strings(opt)
+	return stringListOrEmpty(req), stringListOrEmpty(opt)
+}
+
+func stringListOrEmpty(items []string) cty.Value {
+	if len(items) == 0 {
+		return cty.ListValEmpty(cty.String)
+	}
+	vals := make([]cty.Value, len(items))
+	for i, s := range items {
+		vals[i] = cty.StringVal(s)
+	}
+	return cty.ListVal(vals)
+}
+
+func (d *ModuleSourceData) String() string {
+	data := cty.ObjectVal(map[string]cty.Value{
+		"source":             cty.StringVal(d.Source),
+		"version":            cty.StringVal(d.Version),
+		"variables":          d.Variables,
+		"outputs":            d.Outputs,
+		"required_variables": d.RequiredVariables,
+		"optional_variables": d.OptionalVariables,
+	})
+	r, err := ctyjson.Marshal(data, data.Type())
+	if err != nil {
+		panic(err.Error())
+	}
+	return string(r)
+}

--- a/pkg/data_module_source_test.go
+++ b/pkg/data_module_source_test.go
@@ -1,0 +1,206 @@
+package pkg_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Azure/mapotf/pkg"
+	filesystem "github.com/Azure/mapotf/pkg/fs"
+	"github.com/hashicorp/terraform-config-inspect/tfconfig"
+	"github.com/prashantv/gostub"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubModuleSourceFetcher struct {
+	mod *tfconfig.Module
+	err error
+}
+
+func (s *stubModuleSourceFetcher) Get(source, version string) (*tfconfig.Module, error) {
+	return s.mod, s.err
+}
+
+// fakeAvmNamingModule mirrors the shape of a real AVM module reasonably
+// closely: a couple of required inputs (no Default), a handful of optional
+// inputs with diverse Default types (string, bool, map), a sensitive optional,
+// and two outputs. Required.true is set explicitly because tfconfig populates
+// it from Default-absence at load time (real fixture would derive it via
+// LoadModule, but here we mimic the post-load state directly).
+func fakeAvmNamingModule() *tfconfig.Module {
+	return &tfconfig.Module{
+		Variables: map[string]*tfconfig.Variable{
+			// Required (no default).
+			"name":     {Name: "name", Type: "string", Required: true, Description: "the name"},
+			"location": {Name: "location", Type: "string", Required: true},
+			// Optional, different default types.
+			"tags":        {Name: "tags", Type: "map(string)", Required: false, Default: map[string]interface{}{}},
+			"enable_diag": {Name: "enable_diag", Type: "bool", Required: false, Default: false},
+			"prefix":      {Name: "prefix", Type: "string", Required: false, Default: ""},
+			// Sensitive optional.
+			"password": {Name: "password", Type: "string", Required: false, Default: "", Sensitive: true},
+		},
+		Outputs: map[string]*tfconfig.Output{
+			"id":     {Name: "id", Description: "the id"},
+			"secret": {Name: "secret", Sensitive: true},
+		},
+	}
+}
+
+func TestDataModuleSource_PartitionsRequiredAndOptional(t *testing.T) {
+	mod := fakeAvmNamingModule()
+	stub := gostub.Stub(&pkg.ModuleSourceFetcherFactory, func(ctx context.Context) pkg.TerraformModuleSourceFetcher {
+		return &stubModuleSourceFetcher{mod: mod}
+	}).Stub(&filesystem.Fs, fakeFs(map[string]string{
+		"/main.tf": `resource "azurerm_resource_group" this {
+}
+`,
+	}))
+	defer stub.Reset()
+
+	hclBlocks := newHclBlocks(t, `
+data "module_source" "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "~> 0.4"
+}
+
+transform "update_in_place" req {
+  for_each             = { for i, n in data.module_source.naming.required_variables : format("%04d", i) => n }
+  target_block_address = "resource.azurerm_resource_group.this"
+  asstring {
+    description = each.value
+  }
+}
+
+transform "update_in_place" opt {
+  for_each             = { for i, n in data.module_source.naming.optional_variables : format("%04d", i) => n }
+  target_block_address = "resource.azurerm_resource_group.this"
+  asstring {
+    description = each.value
+  }
+}
+
+transform "update_in_place" vars_keys {
+  for_each             = { for i, n in sort(keys(data.module_source.naming.variables)) : format("%04d", i) => n }
+  target_block_address = "resource.azurerm_resource_group.this"
+  asstring {
+    description = each.value
+  }
+}
+
+transform "update_in_place" out_keys {
+  for_each             = { for i, n in sort(keys(data.module_source.naming.outputs)) : format("%04d", i) => n }
+  target_block_address = "resource.azurerm_resource_group.this"
+  asstring {
+    description = each.value
+  }
+}
+`)
+	cfg, err := pkg.NewMetaProgrammingTFConfig(&pkg.TerraformModuleRef{
+		Dir:    ".",
+		AbsDir: "/",
+	}, nil, nil, nil, context.TODO())
+	require.NoError(t, err)
+	require.NoError(t, cfg.Init(hclBlocks))
+	require.NoError(t, cfg.RunPrePlan())
+	require.NoError(t, cfg.RunPlan())
+
+	got := collectForEachStrings(t, cfg, "update_in_place", []string{
+		"req", "opt", "vars_keys", "out_keys",
+	}, "description")
+
+	// Required variables: alphabetical, partitioned by tfconfig.Variable.Required.
+	assert.Equal(t, []string{"location", "name"}, got["req"])
+	// Optional variables: alphabetical, everything with Required:false.
+	assert.Equal(t, []string{"enable_diag", "password", "prefix", "tags"}, got["opt"])
+	// The full variables object exposes every variable name.
+	assert.Equal(t, []string{"enable_diag", "location", "name", "password", "prefix", "tags"}, got["vars_keys"])
+	// The full outputs object exposes every output name.
+	assert.Equal(t, []string{"id", "secret"}, got["out_keys"])
+}
+
+func TestDataModuleSource_StringJSONShape(t *testing.T) {
+	mod := &tfconfig.Module{
+		Variables: map[string]*tfconfig.Variable{
+			"only_required": {Name: "only_required", Type: "string", Required: true, Description: "d"},
+			"only_optional": {Name: "only_optional", Type: "string", Required: false, Default: "hello"},
+		},
+		Outputs: map[string]*tfconfig.Output{
+			"o": {Name: "o", Description: "out"},
+		},
+	}
+	stub := gostub.Stub(&pkg.ModuleSourceFetcherFactory, func(ctx context.Context) pkg.TerraformModuleSourceFetcher {
+		return &stubModuleSourceFetcher{mod: mod}
+	})
+	defer stub.Reset()
+
+	d := &pkg.ModuleSourceData{
+		BaseData:  &pkg.BaseData{},
+		Source:    "Azure/naming/azurerm",
+		Version:   "~> 0.4",
+	}
+	require.NoError(t, d.ExecuteDuringPlan())
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(d.String()), &got))
+
+	assert.Equal(t, "Azure/naming/azurerm", got["source"])
+	assert.Equal(t, "~> 0.4", got["version"])
+	require.Contains(t, got, "variables")
+	require.Contains(t, got, "outputs")
+	require.Contains(t, got, "required_variables")
+	require.Contains(t, got, "optional_variables")
+
+	req, _ := got["required_variables"].([]interface{})
+	assert.Equal(t, []interface{}{"only_required"}, req)
+	opt, _ := got["optional_variables"].([]interface{})
+	assert.Equal(t, []interface{}{"only_optional"}, opt)
+
+	// outputs object must have no "required" field (outputs are always emitted).
+	outs, _ := got["outputs"].(map[string]interface{})
+	require.NotNil(t, outs)
+	out, _ := outs["o"].(map[string]interface{})
+	require.NotNil(t, out)
+	_, hasRequired := out["required"]
+	assert.False(t, hasRequired, "outputs object must not expose a 'required' field")
+	assert.Equal(t, "out", out["description"])
+	assert.Equal(t, false, out["sensitive"])
+
+	// Variables object exposes per-variable required/type/description/sensitive/default.
+	vars, _ := got["variables"].(map[string]interface{})
+	require.NotNil(t, vars)
+	req1, _ := vars["only_required"].(map[string]interface{})
+	require.NotNil(t, req1)
+	assert.Equal(t, true, req1["required"])
+	assert.Equal(t, "string", req1["type"])
+	assert.Equal(t, "d", req1["description"])
+	assert.Nil(t, req1["default"])
+
+	opt1, _ := vars["only_optional"].(map[string]interface{})
+	require.NotNil(t, opt1)
+	assert.Equal(t, false, opt1["required"])
+	assert.Equal(t, "hello", opt1["default"])
+}
+
+func TestDataModuleSource_EmptyModule(t *testing.T) {
+	mod := &tfconfig.Module{
+		Variables: map[string]*tfconfig.Variable{},
+		Outputs:   map[string]*tfconfig.Output{},
+	}
+	stub := gostub.Stub(&pkg.ModuleSourceFetcherFactory, func(ctx context.Context) pkg.TerraformModuleSourceFetcher {
+		return &stubModuleSourceFetcher{mod: mod}
+	})
+	defer stub.Reset()
+
+	d := &pkg.ModuleSourceData{
+		BaseData: &pkg.BaseData{},
+		Source:   "some/empty/module",
+	}
+	require.NoError(t, d.ExecuteDuringPlan())
+
+	// Empty module must produce empty (not panicked, not null) collections so
+	// downstream `concat(required_variables, optional_variables)` keeps working.
+	assert.True(t, d.RequiredVariables.LengthInt() == 0)
+	assert.True(t, d.OptionalVariables.LengthInt() == 0)
+}

--- a/pkg/data_provider_schema.go
+++ b/pkg/data_provider_schema.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
+
 	"github.com/Azure/golden"
 	"github.com/hashicorp/go-multierror"
 	tfjson "github.com/hashicorp/terraform-json"
@@ -20,9 +22,14 @@ type ProviderSchemaData struct {
 	*BaseData
 	*golden.BaseBlock
 
-	Source    string    `hcl:"provider_source"`
-	Version   string    `hcl:"provider_version"`
-	Resources cty.Value `attribute:"resources"`
+	Source                        string    `hcl:"provider_source"`
+	Version                       string    `hcl:"provider_version"`
+	Resources                     cty.Value `attribute:"resources"`
+	DataSources                   cty.Value `attribute:"data_sources"`
+	ResourcesRequiredAttributes   cty.Value `attribute:"resources_required_attributes"`
+	ResourcesOptionalAttributes   cty.Value `attribute:"resources_optional_attributes"`
+	DataSourcesRequiredAttributes cty.Value `attribute:"data_sources_required_attributes"`
+	DataSourcesOptionalAttributes cty.Value `attribute:"data_sources_optional_attributes"`
 }
 
 func (r *ProviderSchemaData) Type() string {
@@ -35,7 +42,51 @@ func (r *ProviderSchemaData) ExecuteDuringPlan() error {
 		return fmt.Errorf("cannot read `terraform prviders schema` for source %s with version %s: %+v", r.Source, r.Version, err)
 	}
 	r.Resources, err = r.Convert(schemas.ResourceSchemas)
-	return err
+	if err != nil {
+		return err
+	}
+	r.DataSources, err = r.Convert(schemas.DataSourceSchemas)
+	if err != nil {
+		return err
+	}
+	r.ResourcesRequiredAttributes = sortedAttributeNamesByType(schemas.ResourceSchemas, func(a *tfjson.SchemaAttribute) bool { return a.Required })
+	r.ResourcesOptionalAttributes = sortedAttributeNamesByType(schemas.ResourceSchemas, func(a *tfjson.SchemaAttribute) bool { return a.Optional })
+	r.DataSourcesRequiredAttributes = sortedAttributeNamesByType(schemas.DataSourceSchemas, func(a *tfjson.SchemaAttribute) bool { return a.Required })
+	r.DataSourcesOptionalAttributes = sortedAttributeNamesByType(schemas.DataSourceSchemas, func(a *tfjson.SchemaAttribute) bool { return a.Optional })
+	return nil
+}
+
+func sortedAttributeNamesByType(schemas map[string]*tfjson.Schema, keep func(*tfjson.SchemaAttribute) bool) cty.Value {
+	out := make(map[string]cty.Value, len(schemas))
+	for typeName, schema := range schemas {
+		if schema == nil || schema.Block == nil {
+			out[typeName] = cty.ListValEmpty(cty.String)
+			continue
+		}
+		var names []string
+		for attrName, attr := range schema.Block.Attributes {
+			if attr == nil {
+				continue
+			}
+			if keep(attr) {
+				names = append(names, attrName)
+			}
+		}
+		sort.Strings(names)
+		if len(names) == 0 {
+			out[typeName] = cty.ListValEmpty(cty.String)
+			continue
+		}
+		vals := make([]cty.Value, len(names))
+		for i, n := range names {
+			vals[i] = cty.StringVal(n)
+		}
+		out[typeName] = cty.ListVal(vals)
+	}
+	if len(out) == 0 {
+		return cty.EmptyObjectVal
+	}
+	return cty.ObjectVal(out)
 }
 
 func (r *ProviderSchemaData) Convert(schemas map[string]*tfjson.Schema) (cty.Value, error) {

--- a/pkg/data_provider_schema_test.go
+++ b/pkg/data_provider_schema_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/zclconf/go-cty/cty/function/stdlib"
 	"math/big"
 	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
 )
 
@@ -1051,4 +1053,211 @@ func mustDecode(t *testing.T, s string) cty.Value {
 	v, err := stdlib.JSONDecode(cty.StringVal(s))
 	require.NoError(t, err)
 	return v
+}
+
+// TestDataProviderSchema_SortedAttributeLists exercises the four pre-sorted
+// attribute-name lists added in v0.1.4 (resources_required_attributes,
+// resources_optional_attributes, data_sources_required_attributes,
+// data_sources_optional_attributes) plus the new data_sources attribute. The
+// synthetic schema deliberately covers the four tfjson partitions so the
+// `Required` / `Optional` filter behaviour is locked in:
+//
+//   - Required: true                       → in *_required, not in *_optional
+//   - Optional: true                       → in *_optional, not in *_required
+//   - Optional: true, Computed: true       → in *_optional (user-writable)
+//   - Computed: true (alone)               → in neither (pure computed)
+//
+// Each list element is fanned out into one update_in_place transform via
+// for_each, where the for_each key is the original list index (zero-padded so
+// alphabetical key sort preserves the original order) and the asstring body
+// records the attribute name. The test then walks `cfg.GetVertices()` to read
+// the patch block for each generated transform and assert the recovered names
+// match the expected alphabetical ordering.
+func TestDataProviderSchema_SortedAttributeLists(t *testing.T) {
+	syntheticSchema := `{
+      "provider": {
+        "version": 0,
+        "block": {"description_kind": "plain"}
+      },
+      "resource_schemas": {
+        "azurerm_resource_group": {
+          "version": 0,
+          "block": {
+            "attributes": {
+              "name":              {"type": "string", "required": true},
+              "location":          {"type": "string", "required": true},
+              "managed_by":        {"type": "string", "optional": true},
+              "tags":              {"type": ["map", "string"], "optional": true},
+              "id":                {"type": "string", "optional": true, "computed": true},
+              "etag":              {"type": "string", "computed": true}
+            },
+            "description_kind": "plain"
+          }
+        },
+        "azurerm_kv_certificate": {
+          "version": 0,
+          "block": {
+            "attributes": {
+              "key_vault_id":      {"type": "string", "required": true},
+              "name":              {"type": "string", "required": true},
+              "tags":              {"type": ["map", "string"], "optional": true},
+              "version":           {"type": "string", "computed": true}
+            },
+            "description_kind": "plain"
+          }
+        }
+      },
+      "data_source_schemas": {
+        "azurerm_resource_group": {
+          "version": 0,
+          "block": {
+            "attributes": {
+              "name":              {"type": "string", "required": true},
+              "location":          {"type": "string", "computed": true},
+              "tags":              {"type": ["map", "string"], "computed": true},
+              "id":                {"type": "string", "optional": true, "computed": true}
+            },
+            "description_kind": "plain"
+          }
+        }
+      }
+    }
+`
+	stub := gostub.Stub(&pkg.SchemaRetrieverFactory, func(ctx context.Context) pkg.TerraformProviderSchemaRetriever {
+		return mockProviderSchemaRetriever{t: t, jsonSchema: syntheticSchema}
+	}).Stub(&filesystem.Fs, fakeFs(map[string]string{
+		"/main.tf": `resource "azurerm_resource_group" this {
+}
+`,
+	}))
+	defer stub.Reset()
+
+	hclBlocks := newHclBlocks(t, `
+data "provider_schema" this {
+  provider_source  = "Azure/fake"
+  provider_version = ">= 0.1.0"
+}
+
+transform "update_in_place" rg_required {
+  for_each             = { for i, n in data.provider_schema.this.resources_required_attributes["azurerm_resource_group"] : format("%04d", i) => n }
+  target_block_address = "resource.azurerm_resource_group.this"
+  asstring {
+    description = each.value
+  }
+}
+
+transform "update_in_place" rg_optional {
+  for_each             = { for i, n in data.provider_schema.this.resources_optional_attributes["azurerm_resource_group"] : format("%04d", i) => n }
+  target_block_address = "resource.azurerm_resource_group.this"
+  asstring {
+    description = each.value
+  }
+}
+
+transform "update_in_place" kv_required {
+  for_each             = { for i, n in data.provider_schema.this.resources_required_attributes["azurerm_kv_certificate"] : format("%04d", i) => n }
+  target_block_address = "resource.azurerm_resource_group.this"
+  asstring {
+    description = each.value
+  }
+}
+
+transform "update_in_place" ds_rg_required {
+  for_each             = { for i, n in data.provider_schema.this.data_sources_required_attributes["azurerm_resource_group"] : format("%04d", i) => n }
+  target_block_address = "resource.azurerm_resource_group.this"
+  asstring {
+    description = each.value
+  }
+}
+
+transform "update_in_place" ds_rg_optional {
+  for_each             = { for i, n in data.provider_schema.this.data_sources_optional_attributes["azurerm_resource_group"] : format("%04d", i) => n }
+  target_block_address = "resource.azurerm_resource_group.this"
+  asstring {
+    description = each.value
+  }
+}
+
+transform "update_in_place" data_sources_marker {
+  for_each             = { for i, n in sort(keys(data.provider_schema.this.data_sources)) : format("%04d", i) => n }
+  target_block_address = "resource.azurerm_resource_group.this"
+  asstring {
+    description = each.value
+  }
+}
+`)
+	cfg, err := pkg.NewMetaProgrammingTFConfig(&pkg.TerraformModuleRef{
+		Dir:    ".",
+		AbsDir: "/",
+	}, nil, nil, nil, context.TODO())
+	require.NoError(t, err)
+	require.NoError(t, cfg.Init(hclBlocks))
+	require.NoError(t, cfg.RunPrePlan())
+	require.NoError(t, cfg.RunPlan())
+
+	got := collectForEachStrings(t, cfg, "update_in_place", []string{
+		"rg_required",
+		"rg_optional",
+		"kv_required",
+		"ds_rg_required",
+		"ds_rg_optional",
+		"data_sources_marker",
+	}, "description")
+
+	// azurerm_resource_group: required = [location, name] (alphabetical).
+	assert.Equal(t, []string{"location", "name"}, got["rg_required"])
+	// azurerm_resource_group: optional = [id, managed_by, tags]; id is
+	// optional+computed (still user-writable), etag is pure-computed (excluded).
+	assert.Equal(t, []string{"id", "managed_by", "tags"}, got["rg_optional"])
+	// azurerm_kv_certificate: required = [key_vault_id, name]; version is
+	// pure-computed (excluded from both buckets).
+	assert.Equal(t, []string{"key_vault_id", "name"}, got["kv_required"])
+	// data source azurerm_resource_group: required = [name].
+	assert.Equal(t, []string{"name"}, got["ds_rg_required"])
+	// data source azurerm_resource_group: optional = [id] (id is
+	// optional+computed; location and tags are pure-computed).
+	assert.Equal(t, []string{"id"}, got["ds_rg_optional"])
+	// `data_sources` exposes every data source type from the schema.
+	assert.Equal(t, []string{"azurerm_resource_group"}, got["data_sources_marker"])
+}
+
+// collectForEachStrings walks the for_each transform vertices produced by
+// `transform.<transformType>.<baseName>[<key>]` and, for each baseName, returns
+// the ordered slice of values pulled from the named asstring attribute on each
+// generated patch block. Order is by for_each key (zero-padded indexes sort
+// lexicographically into original list order).
+func collectForEachStrings(t *testing.T, cfg *pkg.MetaProgrammingTFConfig, transformType string, baseNames []string, attrName string) map[string][]string {
+	t.Helper()
+	vertices := cfg.GetVertices()
+	out := make(map[string][]string, len(baseNames))
+	for _, base := range baseNames {
+		prefix := "transform." + transformType + "." + base + "["
+		keys := make([]string, 0)
+		entries := make(map[string]string)
+		for vk, vb := range vertices {
+			if !strings.HasPrefix(vk, prefix) || !strings.HasSuffix(vk, "]") {
+				continue
+			}
+			forEachKey := strings.TrimSuffix(strings.TrimPrefix(vk, prefix), "]")
+			upd, ok := vb.(*pkg.UpdateInPlaceTransform)
+			require.Truef(t, ok, "vertex %q is not an UpdateInPlaceTransform", vk)
+			attr := upd.UpdateBlock().Body().GetAttribute(attrName)
+			require.NotNilf(t, attr, "vertex %q has no %q attribute on its patch block", vk, attrName)
+			rawTokens := attr.Expr().BuildTokens(nil).Bytes()
+			value := strings.TrimSpace(string(rawTokens))
+			// Strip enclosing quotes from the asstring-rendered literal.
+			if len(value) >= 2 && value[0] == '"' && value[len(value)-1] == '"' {
+				value = value[1 : len(value)-1]
+			}
+			keys = append(keys, forEachKey)
+			entries[forEachKey] = value
+		}
+		sort.Strings(keys)
+		ordered := make([]string, len(keys))
+		for i, k := range keys {
+			ordered[i] = entries[k]
+		}
+		out[base] = ordered
+	}
+	return out
 }

--- a/pkg/init.go
+++ b/pkg/init.go
@@ -32,6 +32,7 @@ func registerData() {
 	golden.RegisterBlock(new(ProviderSchemaData))
 	golden.RegisterBlock(new(TerraformData))
 	golden.RegisterBlock(new(DataSourceData))
+	golden.RegisterBlock(new(EphemeralData))
 	golden.RegisterBlock(new(DataVariable))
 	golden.RegisterBlock(new(DataOutput))
 	golden.RegisterBlock(new(DataLocal))

--- a/pkg/init.go
+++ b/pkg/init.go
@@ -38,4 +38,5 @@ func registerData() {
 	golden.RegisterBlock(new(DataLocal))
 	golden.RegisterBlock(new(DataModule))
 	golden.RegisterBlock(new(DataMoved))
+	golden.RegisterBlock(new(ModuleSourceData))
 }

--- a/pkg/module_source.go
+++ b/pkg/module_source.go
@@ -1,0 +1,89 @@
+package pkg
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/hashicorp/terraform-config-inspect/tfconfig"
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+// TerraformModuleSourceFetcher fetches a remote Terraform module (registry
+// reference, git URL, etc.) and returns its parsed metadata via
+// terraform-config-inspect. Backed by `terraform get`, so only modules are
+// downloaded — no provider plugins.
+type TerraformModuleSourceFetcher interface {
+	Get(source, version string) (*tfconfig.Module, error)
+}
+
+type TerraformCliModuleSourceFetcher struct {
+	ctx context.Context
+}
+
+func NewTerraformCliModuleSourceFetcher(ctx context.Context) TerraformModuleSourceFetcher {
+	return TerraformCliModuleSourceFetcher{ctx: ctx}
+}
+
+func (t TerraformCliModuleSourceFetcher) Get(source, version string) (*tfconfig.Module, error) {
+	tmpFolder, err := os.MkdirTemp("", "mapotf-module-*")
+	if err != nil {
+		return nil, fmt.Errorf("error creating temp module folder: %s", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(tmpFolder)
+	}()
+
+	var versionLine string
+	if version != "" {
+		versionLine = fmt.Sprintf("  version = %q\n", version)
+	}
+	tfCode := fmt.Sprintf(`module "x" {
+  source = %q
+%s}
+`, source, versionLine)
+	if err := os.WriteFile(filepath.Join(tmpFolder, "main.tf"), []byte(tfCode), 0600); err != nil {
+		return nil, fmt.Errorf("error writing temp TF code file: %s", err)
+	}
+
+	execPath, err := t.getTerraformPath()
+	if err != nil {
+		return nil, err
+	}
+	tf, err := tfexec.NewTerraform(tmpFolder, execPath)
+	if err != nil {
+		return nil, fmt.Errorf("error running NewTerraform: %w", err)
+	}
+	if err := tf.Get(t.ctx); err != nil {
+		return nil, fmt.Errorf("error running terraform get for module %q version %q: %w", source, version, err)
+	}
+
+	moduleDir := filepath.Join(tmpFolder, ".terraform", "modules", "x")
+	mod, diags := tfconfig.LoadModule(moduleDir)
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("error loading module from %s: %s", moduleDir, diags.Error())
+	}
+	return mod, nil
+}
+
+func (t TerraformCliModuleSourceFetcher) getTerraformPath() (string, error) {
+	var cmd *exec.Cmd
+	if t.isWindows() {
+		cmd = exec.Command("where", "terraform")
+	} else {
+		cmd = exec.Command("which", "terraform")
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func (t TerraformCliModuleSourceFetcher) isWindows() bool {
+	return runtime.GOOS == "windows"
+}

--- a/pkg/mptf_config.go
+++ b/pkg/mptf_config.go
@@ -22,16 +22,17 @@ var _ golden.Config = &MetaProgrammingTFConfig{}
 
 type MetaProgrammingTFConfig struct {
 	*golden.BaseConfig
-	resourceBlocks map[string]*terraform.RootBlock
-	dataBlocks     map[string]*terraform.RootBlock
-	variableBlocks map[string]*terraform.RootBlock
-	localBlocks    map[string]*terraform.RootBlock
-	outputBlocks   map[string]*terraform.RootBlock
-	moduleBlocks   map[string]*terraform.RootBlock
-	movedBlocks    map[string]*terraform.RootBlock
-	terraformBlock *terraform.RootBlock
-	allRootBlocks  []*terraform.RootBlock
-	module         *terraform.Module
+	resourceBlocks  map[string]*terraform.RootBlock
+	dataBlocks      map[string]*terraform.RootBlock
+	ephemeralBlocks map[string]*terraform.RootBlock
+	variableBlocks  map[string]*terraform.RootBlock
+	localBlocks     map[string]*terraform.RootBlock
+	outputBlocks    map[string]*terraform.RootBlock
+	moduleBlocks    map[string]*terraform.RootBlock
+	movedBlocks     map[string]*terraform.RootBlock
+	terraformBlock  *terraform.RootBlock
+	allRootBlocks   []*terraform.RootBlock
+	module          *terraform.Module
 }
 
 func NewMetaProgrammingTFConfig(m *TerraformModuleRef, varConfigDir *string, hclBlocks []*golden.HclBlock, cliFlagAssignedVars []golden.CliFlagAssignedVariables, ctx context.Context) (*MetaProgrammingTFConfig, error) {
@@ -63,6 +64,7 @@ func (c *MetaProgrammingTFConfig) reloadTerraformModule(m *TerraformModuleRef) e
 	}
 	c.resourceBlocks = groupByAddress(module.ResourceBlocks)
 	c.dataBlocks = groupByAddress(module.DataBlocks)
+	c.ephemeralBlocks = groupByAddress(module.EphemeralBlocks)
 	c.moduleBlocks = groupByAddress(module.ModuleBlocks)
 	c.variableBlocks = groupByAddress(module.Variables)
 	c.outputBlocks = groupByAddress(module.Outputs)
@@ -86,6 +88,10 @@ func (c *MetaProgrammingTFConfig) ResourceBlocks() []*terraform.RootBlock {
 
 func (c *MetaProgrammingTFConfig) DataBlocks() []*terraform.RootBlock {
 	return c.slice(c.dataBlocks)
+}
+
+func (c *MetaProgrammingTFConfig) EphemeralBlocks() []*terraform.RootBlock {
+	return c.slice(c.ephemeralBlocks)
 }
 
 func (c *MetaProgrammingTFConfig) VariableBlocks() []*terraform.RootBlock {
@@ -118,6 +124,9 @@ func (c *MetaProgrammingTFConfig) RootBlock(address string) *terraform.RootBlock
 	}
 	if strings.HasPrefix(address, "data.") {
 		return c.dataBlocks[address]
+	}
+	if strings.HasPrefix(address, "ephemeral.") {
+		return c.ephemeralBlocks[address]
 	}
 	if strings.HasPrefix(address, "variable.") {
 		return c.variableBlocks[address]

--- a/pkg/terraform/module.go
+++ b/pkg/terraform/module.go
@@ -175,8 +175,12 @@ func (m *Module) AddBlock(fileName string, block *hclwrite.Block) {
 	if len(tokens) > 1 && tokens[len(tokens)-1].Type != hclsyntax.TokenNewline {
 		writeFile.Body().AppendNewline()
 	}
-	writeFile.Body().AppendUnstructuredTokens(block.BuildTokens(nil))
-	writeFile.Body().AppendNewline()
+	// AppendBlock (rather than AppendUnstructuredTokens(block.BuildTokens(nil)))
+	// inserts the block as a structured element, so subsequent body.Blocks()
+	// walks — including the ones inside RemoveBlock — can find it. Any extra
+	// trailing whitespace is canonicalized by normalizeFileWhitespace in
+	// SaveToDisk.
+	writeFile.Body().AppendBlock(block)
 }
 
 func (m *Module) RemoveBlock(block *hclwrite.Block) {

--- a/pkg/terraform/module.go
+++ b/pkg/terraform/module.go
@@ -23,6 +23,9 @@ var wantedTypes = map[string]func(module *Module) *[]*RootBlock{
 	"data": func(m *Module) *[]*RootBlock {
 		return &m.DataBlocks
 	},
+	"ephemeral": func(m *Module) *[]*RootBlock {
+		return &m.EphemeralBlocks
+	},
 	"module": func(m *Module) *[]*RootBlock {
 		return &m.ModuleBlocks
 	},
@@ -41,6 +44,7 @@ type Module struct {
 	lock            *sync.Mutex
 	ResourceBlocks  []*RootBlock
 	DataBlocks      []*RootBlock
+	EphemeralBlocks []*RootBlock
 	ModuleBlocks    []*RootBlock
 	TerraformBlocks []*RootBlock
 	Variables       []*RootBlock
@@ -253,7 +257,8 @@ func (m *Module) Blocks() []*RootBlock {
 	var blocks []*RootBlock
 	linq.From(m.TerraformBlocks).Concat(linq.From(m.Locals)).
 		Concat(linq.From(m.Outputs)).Concat(linq.From(m.Variables)).
-		Concat(linq.From(m.DataBlocks)).Concat(linq.From(m.ResourceBlocks)).
+		Concat(linq.From(m.DataBlocks)).Concat(linq.From(m.EphemeralBlocks)).
+		Concat(linq.From(m.ResourceBlocks)).
 		Concat(linq.From(m.ModuleBlocks)).Concat(linq.From(m.MovedBlocks)).
 		ToSlice(&blocks)
 	return blocks

--- a/pkg/terraform/module_test.go
+++ b/pkg/terraform/module_test.go
@@ -309,3 +309,67 @@ func createResourceBlock(resourceType, name, resourceName string) *hclwrite.Bloc
 	b.Body().SetAttributeValue("name", cty.StringVal(resourceName))
 	return b
 }
+
+// TestModule_AddBlockThenRemoveBlock_Roundtrip asserts that a block added via
+// AddBlock is visible to subsequent RemoveBlock calls. Regression test for the
+// "AddBlock uses unstructured tokens so body.Blocks() can't see the added
+// block" bug — see RemoveBlock implementation walking body.Blocks().
+func TestModule_AddBlockThenRemoveBlock_Roundtrip(t *testing.T) {
+	mockFs := afero.NewMemMapFs()
+	stub := gostub.Stub(&filesystem.Fs, mockFs)
+	defer stub.Reset()
+
+	require.NoError(t, mockFs.MkdirAll("tmp", 0755))
+
+	m := &Module{
+		Dir:        "tmp",
+		AbsDir:     "tmp",
+		writeFiles: make(map[string]*hclwrite.File),
+		lock:       &sync.Mutex{},
+	}
+
+	block := createResourceBlock("azurerm_resource_group", "added", "added-rg")
+	m.AddBlock("new_file.tf", block)
+
+	// RemoveBlock must find the block we just added; pointer-equality pass
+	// or type+labels fallback must see it.
+	m.RemoveBlock(block)
+
+	require.NoError(t, m.SaveToDisk())
+
+	content, err := afero.ReadFile(mockFs, "tmp/new_file.tf")
+	require.NoError(t, err)
+	assert.Equal(t, "", string(content),
+		"after AddBlock+RemoveBlock the file should be empty; if not, AddBlock isn't inserting the block in a form that body.Blocks() can find")
+}
+
+// TestModule_AddBlockThenRemoveBlock_ByTypeAndLabels covers the type+labels
+// fallback path in RemoveBlock: a NEW *hclwrite.Block (different pointer) with
+// matching type and labels should still be removed.
+func TestModule_AddBlockThenRemoveBlock_ByTypeAndLabels(t *testing.T) {
+	mockFs := afero.NewMemMapFs()
+	stub := gostub.Stub(&filesystem.Fs, mockFs)
+	defer stub.Reset()
+
+	require.NoError(t, mockFs.MkdirAll("tmp", 0755))
+
+	m := &Module{
+		Dir:        "tmp",
+		AbsDir:     "tmp",
+		writeFiles: make(map[string]*hclwrite.File),
+		lock:       &sync.Mutex{},
+	}
+
+	added := createResourceBlock("azurerm_resource_group", "added", "added-rg")
+	m.AddBlock("new_file.tf", added)
+
+	// Remove by a fresh block with the same type+labels (pointer differs).
+	matcher := hclwrite.NewBlock("resource", []string{"azurerm_resource_group", "added"})
+	m.RemoveBlock(matcher)
+
+	require.NoError(t, m.SaveToDisk())
+
+	content, err := afero.ReadFile(mockFs, "tmp/new_file.tf")
+	require.NoError(t, err)
+	assert.Equal(t, "", string(content))
+}

--- a/pkg/terraform/module_test.go
+++ b/pkg/terraform/module_test.go
@@ -21,9 +21,11 @@ func TestLoadModuleShouldLoadAllTerraformFiles(t *testing.T) {
 	defer stub.Reset()
 	_ = afero.WriteFile(mockFs, "/main.tf", []byte(`resource "fake_resource" this {}
 data "fake_data" this {}
+ephemeral "fake_ephemeral" this {}
 `), 0644)
 	_ = afero.WriteFile(mockFs, "/main2.tf", []byte(`resource "fake_resource" that {}
 data "fake_data" that {}
+ephemeral "fake_ephemeral" that {}
 `), 0644)
 	sut, err := LoadModule(ModuleRef{
 		Dir:    ".",
@@ -32,6 +34,7 @@ data "fake_data" that {}
 	require.NoError(t, err)
 	assert.Len(t, sut.ResourceBlocks, 2)
 	assert.Len(t, sut.DataBlocks, 2)
+	assert.Len(t, sut.EphemeralBlocks, 2)
 }
 
 func TestModule_SaveToDisk(t *testing.T) {

--- a/pkg/transform_move_block.go
+++ b/pkg/transform_move_block.go
@@ -31,7 +31,10 @@ func (m *MoveBlockTransform) Apply() error {
 	if block.Range().Filename == m.FileName {
 		return nil
 	}
-	cfg.AddBlock(m.FileName, writeBlock)
+	// RemoveBlock must precede AddBlock: the new structured AppendBlock used
+	// by AddBlock requires the block not already be owned by another body.
+	// (Same pattern as sort_blocks_in_file.)
 	cfg.module.RemoveBlock(writeBlock)
+	cfg.AddBlock(m.FileName, writeBlock)
 	return nil
 }

--- a/pkg/transform_new_block_test.go
+++ b/pkg/transform_new_block_test.go
@@ -361,7 +361,6 @@ func TestNewBlockTransform_MalformedNewBlockShouldNotBlockSave(t *testing.T) {
 	expected := `variable "test" {
   type =.string
 }
-
 `
 	actual := string(after)
 	assert.Equal(t, expected, actual)

--- a/pkg/transform_reorder_attributes.go
+++ b/pkg/transform_reorder_attributes.go
@@ -21,23 +21,23 @@ var _ Transform = &ReorderAttributesTransform{}
 //     are identified by their label (`X`), so they line up with the static
 //     block they emit.
 //   - Elements named in `head_attributes` come first, in the listed order.
-//   - Elements named in `tail_attributes` come last, in the listed order.
-//   - Every other element is the "middle". By default the middle is sorted
-//     alphabetically by name; set `sort_middle_alphabetically = false` to
+//   - Elements named in `foot_attributes` come last, in the listed order.
+//   - Every other element is the "body". By default the body is sorted
+//     alphabetically by name; set `sort_body_alphabetically = false` to
 //     preserve the original source order instead.
-//   - When `head_tail_line_breaks` is true (default) a blank line is inserted
-//     between the head section and the middle, and between the middle and the
-//     tail section. Set to `false` to suppress these blank lines.
+//   - When `head_foot_line_breaks` is true (default) a blank line is inserted
+//     between the head section and the body, and between the body and the
+//     foot section. Set to `false` to suppress these blank lines.
 //   - Every nested block in the output is preceded by a blank line, except
 //     when the previous element is a nested block sharing the same orderable
 //     name. Adjacent same-kind siblings (e.g. two `validation {}` blocks of
 //     a variable, two `dynamic "subnet" {}` blocks of a resource) stay
 //     grouped without a blank line between them, matching typical Terraform
-//     formatting. If a section boundary (head/tail) coincides with the
+//     formatting. If a section boundary (head/foot) coincides with the
 //     adjacency the section blank line still wins.
-//   - Names in `head_attributes` / `tail_attributes` that are not present on
+//   - Names in `head_attributes` / `foot_attributes` that are not present on
 //     the block are silently skipped.
-//   - The same name in both `head_attributes` and `tail_attributes` is a
+//   - The same name in both `head_attributes` and `foot_attributes` is a
 //     configuration error.
 //
 // This transform never adds, removes, or mutates attribute values — only the
@@ -45,11 +45,11 @@ var _ Transform = &ReorderAttributesTransform{}
 type ReorderAttributesTransform struct {
 	*golden.BaseBlock
 	*BaseTransform
-	TargetBlockAddress       string   `hcl:"target_block_address"`
-	HeadAttributes           []string `hcl:"head_attributes,optional"`
-	TailAttributes           []string `hcl:"tail_attributes,optional"`
-	HeadTailLineBreaks       *bool    `hcl:"head_tail_line_breaks,optional"`
-	SortMiddleAlphabetically *bool    `hcl:"sort_middle_alphabetically,optional"`
+	TargetBlockAddress     string   `hcl:"target_block_address"`
+	HeadAttributes         []string `hcl:"head_attributes,optional"`
+	FootAttributes         []string `hcl:"foot_attributes,optional"`
+	HeadFootLineBreaks     *bool    `hcl:"head_foot_line_breaks,optional"`
+	SortBodyAlphabetically *bool    `hcl:"sort_body_alphabetically,optional"`
 }
 
 func (r *ReorderAttributesTransform) Type() string {
@@ -64,10 +64,10 @@ func (r *ReorderAttributesTransform) Apply() error {
 	}
 
 	headSet := toNameSet(r.HeadAttributes)
-	tailSet := toNameSet(r.TailAttributes)
+	footSet := toNameSet(r.FootAttributes)
 	for name := range headSet {
-		if _, conflict := tailSet[name]; conflict {
-			return fmt.Errorf("reorder_attributes: attribute %q cannot be in both head_attributes and tail_attributes", name)
+		if _, conflict := footSet[name]; conflict {
+			return fmt.Errorf("reorder_attributes: attribute %q cannot be in both head_attributes and foot_attributes", name)
 		}
 	}
 
@@ -80,37 +80,37 @@ func (r *ReorderAttributesTransform) Apply() error {
 
 	elements := buildReorderElements(writeAttrs, writeBlocks, block)
 
-	headElems, midElems, tailElems := partitionReorderElements(elements, r.HeadAttributes, r.TailAttributes)
-	sortReorderMiddle(midElems, r.useSortMiddleAlphabetically())
+	headElems, bodyElems, footElems := partitionReorderElements(elements, r.HeadAttributes, r.FootAttributes)
+	sortReorderBody(bodyElems, r.useSortBodyAlphabetically())
 
-	final := make([]reorderElement, 0, len(headElems)+len(midElems)+len(tailElems))
+	final := make([]reorderElement, 0, len(headElems)+len(bodyElems)+len(footElems))
 	final = append(final, headElems...)
-	final = append(final, midElems...)
-	final = append(final, tailElems...)
+	final = append(final, bodyElems...)
+	final = append(final, footElems...)
 
 	body.Clear()
 	body.AppendNewline()
-	emitReorderElements(body, final, len(headElems), len(headElems)+len(midElems), r.useHeadTailLineBreaks())
+	emitReorderElements(body, final, len(headElems), len(headElems)+len(bodyElems), r.useHeadFootLineBreaks())
 	return nil
 }
 
-func (r *ReorderAttributesTransform) useHeadTailLineBreaks() bool {
-	if r.HeadTailLineBreaks == nil {
+func (r *ReorderAttributesTransform) useHeadFootLineBreaks() bool {
+	if r.HeadFootLineBreaks == nil {
 		return true
 	}
-	return *r.HeadTailLineBreaks
+	return *r.HeadFootLineBreaks
 }
 
-func (r *ReorderAttributesTransform) useSortMiddleAlphabetically() bool {
-	if r.SortMiddleAlphabetically == nil {
+func (r *ReorderAttributesTransform) useSortBodyAlphabetically() bool {
+	if r.SortBodyAlphabetically == nil {
 		return true
 	}
-	return *r.SortMiddleAlphabetically
+	return *r.SortBodyAlphabetically
 }
 
 // reorderElement represents one orderable item in a block body — either an
 // attribute or a nested block. Source position is captured when known so the
-// "preserve source order" middle mode can sort attributes and nested blocks by
+// "preserve source order" body mode can sort attributes and nested blocks by
 // the line/column they originally appeared on.
 type reorderElement struct {
 	name      string
@@ -127,7 +127,7 @@ type reorderElement struct {
 // resolved from the matching read-side `*hclsyntax.Body` when available.
 // Elements added by a previous transform (no source-side counterpart) are
 // flagged `hasSource = false` and sorted alphabetically among themselves in
-// either middle mode.
+// either body mode.
 func buildReorderElements(writeAttrs map[string]*hclwrite.Attribute, writeBlocks []*hclwrite.Block, block *terraform.RootBlock) []reorderElement {
 	elements := make([]reorderElement, 0, len(writeAttrs)+len(writeBlocks))
 
@@ -162,40 +162,40 @@ func buildReorderElements(writeAttrs map[string]*hclwrite.Attribute, writeBlocks
 	return elements
 }
 
-// partitionReorderElements splits `elements` into head, middle, and tail
-// slices according to `head` and `tail` name lists. Multiple elements that
+// partitionReorderElements splits `elements` into head, body, and foot
+// slices according to `head` and `foot` name lists. Multiple elements that
 // share a name (e.g. two `nested {}` blocks of the same type) are grouped
-// together at the head or tail position, preserving their write-side order
+// together at the head or foot position, preserving their write-side order
 // within the group.
-func partitionReorderElements(elements []reorderElement, head, tail []string) (headElems, midElems, tailElems []reorderElement) {
+func partitionReorderElements(elements []reorderElement, head, foot []string) (headElems, bodyElems, footElems []reorderElement) {
 	headSet := toNameSet(head)
-	tailSet := toNameSet(tail)
+	footSet := toNameSet(foot)
 	byName := make(map[string][]reorderElement)
 	for _, el := range elements {
 		if _, ok := headSet[el.name]; ok {
 			byName[el.name] = append(byName[el.name], el)
 			continue
 		}
-		if _, ok := tailSet[el.name]; ok {
+		if _, ok := footSet[el.name]; ok {
 			byName[el.name] = append(byName[el.name], el)
 			continue
 		}
-		midElems = append(midElems, el)
+		bodyElems = append(bodyElems, el)
 	}
 	for _, name := range head {
 		headElems = append(headElems, byName[name]...)
 	}
-	for _, name := range tail {
-		tailElems = append(tailElems, byName[name]...)
+	for _, name := range foot {
+		footElems = append(footElems, byName[name]...)
 	}
 	return
 }
 
-// sortReorderMiddle stably sorts the middle slice in-place. When
-// `alphabetical` is true the order is `name` ascending. When false the order
-// is the original source position (line then column), with no-source elements
+// sortReorderBody stably sorts the body slice in-place. When `alphabetical`
+// is true the order is `name` ascending. When false the order is the
+// original source position (line then column), with no-source elements
 // (added by other transforms) appended afterwards in alphabetical order.
-func sortReorderMiddle(elems []reorderElement, alphabetical bool) {
+func sortReorderBody(elems []reorderElement, alphabetical bool) {
 	if alphabetical {
 		sort.SliceStable(elems, func(i, j int) bool {
 			return elems[i].name < elems[j].name
@@ -224,9 +224,9 @@ func sortReorderMiddle(elems []reorderElement, alphabetical bool) {
 // between sections and before nested blocks per the documented rules.
 //
 //   - `headEnd` is the index of the first non-head element.
-//   - `tailStart` is the index of the first tail element.
-//   - `headTailLineBreaks` controls whether blank lines are emitted at the
-//     head→middle and middle→tail section boundaries.
+//   - `footStart` is the index of the first foot element.
+//   - `headFootLineBreaks` controls whether blank lines are emitted at the
+//     head→body and body→foot section boundaries.
 //
 // A blank line is emitted before a nested block to match typical Terraform
 // formatting, with one exception: when the previous element is a nested
@@ -236,17 +236,17 @@ func sortReorderMiddle(elems []reorderElement, alphabetical bool) {
 // line, even when it falls between same-kind siblings, because the user
 // asked for that separator explicitly.
 //
-// When the head→middle and middle→tail boundaries collapse to the same
-// index (empty middle) only one blank line is emitted, because `needBlank`
-// is a single boolean per iteration.
-func emitReorderElements(body *hclwrite.Body, elements []reorderElement, headEnd, tailStart int, headTailLineBreaks bool) {
+// When the head→body and body→foot boundaries collapse to the same index
+// (empty body) only one blank line is emitted, because `needBlank` is a
+// single boolean per iteration.
+func emitReorderElements(body *hclwrite.Body, elements []reorderElement, headEnd, footStart int, headFootLineBreaks bool) {
 	for i, el := range elements {
 		if i > 0 {
 			needBlank := false
-			if headTailLineBreaks && i == headEnd && headEnd > 0 && headEnd < len(elements) {
+			if headFootLineBreaks && i == headEnd && headEnd > 0 && headEnd < len(elements) {
 				needBlank = true
 			}
-			if headTailLineBreaks && i == tailStart && tailStart > 0 && tailStart < len(elements) {
+			if headFootLineBreaks && i == footStart && footStart > 0 && footStart < len(elements) {
 				needBlank = true
 			}
 			if el.isNested {

--- a/pkg/transform_reorder_attributes.go
+++ b/pkg/transform_reorder_attributes.go
@@ -22,9 +22,11 @@ var _ Transform = &ReorderAttributesTransform{}
 //     block they emit.
 //   - Elements named in `head_attributes` come first, in the listed order.
 //   - Elements named in `foot_attributes` come last, in the listed order.
-//   - Every other element is the "body". By default the body is sorted
-//     alphabetically by name; set `sort_body_alphabetically = false` to
-//     preserve the original source order instead.
+//   - Elements named in `body_attributes` come first within the body section,
+//     in the listed order. Every other element of the body section is then
+//     appended; by default that remainder is sorted alphabetically by name.
+//     Set `sort_body_alphabetically = false` to preserve original source order
+//     for the unlisted body remainder instead.
 //   - When `head_foot_line_breaks` is true (default) a blank line is inserted
 //     between the head section and the body, and between the body and the
 //     foot section. Set to `false` to suppress these blank lines.
@@ -35,10 +37,10 @@ var _ Transform = &ReorderAttributesTransform{}
 //     grouped without a blank line between them, matching typical Terraform
 //     formatting. If a section boundary (head/foot) coincides with the
 //     adjacency the section blank line still wins.
-//   - Names in `head_attributes` / `foot_attributes` that are not present on
-//     the block are silently skipped.
-//   - The same name in both `head_attributes` and `foot_attributes` is a
-//     configuration error.
+//   - Names in `head_attributes` / `body_attributes` / `foot_attributes` that
+//     are not present on the block are silently skipped.
+//   - The same name appearing in more than one of `head_attributes`,
+//     `body_attributes`, or `foot_attributes` is a configuration error.
 //
 // This transform never adds, removes, or mutates attribute values — only the
 // layout changes.
@@ -47,6 +49,7 @@ type ReorderAttributesTransform struct {
 	*BaseTransform
 	TargetBlockAddress     string   `hcl:"target_block_address"`
 	HeadAttributes         []string `hcl:"head_attributes,optional"`
+	BodyAttributes         []string `hcl:"body_attributes,optional"`
 	FootAttributes         []string `hcl:"foot_attributes,optional"`
 	HeadFootLineBreaks     *bool    `hcl:"head_foot_line_breaks,optional"`
 	SortBodyAlphabetically *bool    `hcl:"sort_body_alphabetically,optional"`
@@ -63,12 +66,8 @@ func (r *ReorderAttributesTransform) Apply() error {
 		return fmt.Errorf("cannot find block: %s", r.TargetBlockAddress)
 	}
 
-	headSet := toNameSet(r.HeadAttributes)
-	footSet := toNameSet(r.FootAttributes)
-	for name := range headSet {
-		if _, conflict := footSet[name]; conflict {
-			return fmt.Errorf("reorder_attributes: attribute %q cannot be in both head_attributes and foot_attributes", name)
-		}
+	if err := validateReorderSectionOverlap(r.HeadAttributes, r.BodyAttributes, r.FootAttributes); err != nil {
+		return err
 	}
 
 	body := block.WriteBlock.Body()
@@ -80,8 +79,9 @@ func (r *ReorderAttributesTransform) Apply() error {
 
 	elements := buildReorderElements(writeAttrs, writeBlocks, block)
 
-	headElems, bodyElems, footElems := partitionReorderElements(elements, r.HeadAttributes, r.FootAttributes)
-	sortReorderBody(bodyElems, r.useSortBodyAlphabetically())
+	headElems, listedBodyElems, unlistedBodyElems, footElems := partitionReorderElements(elements, r.HeadAttributes, r.BodyAttributes, r.FootAttributes)
+	sortReorderBody(unlistedBodyElems, r.useSortBodyAlphabetically())
+	bodyElems := append(listedBodyElems, unlistedBodyElems...)
 
 	final := make([]reorderElement, 0, len(headElems)+len(bodyElems)+len(footElems))
 	final = append(final, headElems...)
@@ -162,13 +162,16 @@ func buildReorderElements(writeAttrs map[string]*hclwrite.Attribute, writeBlocks
 	return elements
 }
 
-// partitionReorderElements splits `elements` into head, body, and foot
-// slices according to `head` and `foot` name lists. Multiple elements that
-// share a name (e.g. two `nested {}` blocks of the same type) are grouped
-// together at the head or foot position, preserving their write-side order
-// within the group.
-func partitionReorderElements(elements []reorderElement, head, foot []string) (headElems, bodyElems, footElems []reorderElement) {
+// partitionReorderElements splits `elements` into head, listed-body,
+// unlisted-body, and foot slices according to `head`, `body`, and `foot`
+// name lists. Multiple elements that share a name (e.g. two `nested {}`
+// blocks of the same type) are grouped together at the head, listed-body, or
+// foot position, preserving their write-side order within the group.
+// Elements whose names are not mentioned in any of the three lists land in
+// `unlistedBodyElems` and are sorted later by `sortReorderBody`.
+func partitionReorderElements(elements []reorderElement, head, body, foot []string) (headElems, listedBodyElems, unlistedBodyElems, footElems []reorderElement) {
 	headSet := toNameSet(head)
+	bodySet := toNameSet(body)
 	footSet := toNameSet(foot)
 	byName := make(map[string][]reorderElement)
 	for _, el := range elements {
@@ -180,15 +183,45 @@ func partitionReorderElements(elements []reorderElement, head, foot []string) (h
 			byName[el.name] = append(byName[el.name], el)
 			continue
 		}
-		bodyElems = append(bodyElems, el)
+		if _, ok := bodySet[el.name]; ok {
+			byName[el.name] = append(byName[el.name], el)
+			continue
+		}
+		unlistedBodyElems = append(unlistedBodyElems, el)
 	}
 	for _, name := range head {
 		headElems = append(headElems, byName[name]...)
+	}
+	for _, name := range body {
+		listedBodyElems = append(listedBodyElems, byName[name]...)
 	}
 	for _, name := range foot {
 		footElems = append(footElems, byName[name]...)
 	}
 	return
+}
+
+// validateReorderSectionOverlap returns an error if any name appears in more
+// than one of head / body / foot. The error message names both sections so
+// the user can fix the duplicate immediately.
+func validateReorderSectionOverlap(head, body, foot []string) error {
+	headSet := toNameSet(head)
+	bodySet := toNameSet(body)
+	footSet := toNameSet(foot)
+	for name := range headSet {
+		if _, ok := bodySet[name]; ok {
+			return fmt.Errorf("reorder_attributes: attribute %q cannot be in both head_attributes and body_attributes", name)
+		}
+		if _, ok := footSet[name]; ok {
+			return fmt.Errorf("reorder_attributes: attribute %q cannot be in both head_attributes and foot_attributes", name)
+		}
+	}
+	for name := range bodySet {
+		if _, ok := footSet[name]; ok {
+			return fmt.Errorf("reorder_attributes: attribute %q cannot be in both body_attributes and foot_attributes", name)
+		}
+	}
+	return nil
 }
 
 // sortReorderBody stably sorts the body slice in-place. When `alphabetical`

--- a/pkg/transform_reorder_attributes_test.go
+++ b/pkg/transform_reorder_attributes_test.go
@@ -49,12 +49,12 @@ variable "example" {
 `,
 		},
 		{
-			desc: "head_and_tail_reorder",
+			desc: "head_and_foot_reorder",
 			mptf: `
 transform "reorder_attributes" this {
   target_block_address = "module.example"
   head_attributes      = ["source", "version"]
-  tail_attributes      = ["depends_on"]
+  foot_attributes      = ["depends_on"]
 }
 `,
 			tfConfig: `
@@ -98,12 +98,12 @@ variable "example" {
 `,
 		},
 		{
-			desc: "head_tail_overlap_returns_error",
+			desc: "head_foot_overlap_returns_error",
 			mptf: `
 transform "reorder_attributes" this {
   target_block_address = "variable.example"
   head_attributes      = ["type"]
-  tail_attributes      = ["type"]
+  foot_attributes      = ["type"]
 }
 `,
 			tfConfig: `
@@ -113,15 +113,15 @@ variable "example" {
 `,
 			expected:       ``,
 			wantErr:        true,
-			errorSubstring: "cannot be in both head_attributes and tail_attributes",
+			errorSubstring: "cannot be in both head_attributes and foot_attributes",
 		},
 		{
-			desc: "nested_block_sorts_into_middle_alphabetically_with_blank_line",
+			desc: "nested_block_sorts_into_body_alphabetically_with_blank_line",
 			mptf: `
 transform "reorder_attributes" this {
   target_block_address = "resource.fake_resource.this"
   head_attributes      = ["count", "for_each"]
-  tail_attributes      = ["depends_on"]
+  foot_attributes      = ["depends_on"]
 }
 `,
 			tfConfig: `
@@ -189,13 +189,13 @@ variable "other" {
 			errorSubstring: "cannot find block",
 		},
 		{
-			desc: "head_tail_line_breaks_false_suppresses_section_blanks",
+			desc: "head_foot_line_breaks_false_suppresses_section_blanks",
 			mptf: `
 transform "reorder_attributes" this {
   target_block_address     = "module.example"
   head_attributes          = ["source", "version"]
-  tail_attributes          = ["depends_on"]
-  head_tail_line_breaks    = false
+  foot_attributes          = ["depends_on"]
+  head_foot_line_breaks    = false
 }
 `,
 			tfConfig: `
@@ -246,11 +246,11 @@ resource "fake_resource" this {
 `,
 		},
 		{
-			desc: "nested_block_listed_in_tail_renders_last",
+			desc: "nested_block_listed_in_foot_renders_last",
 			mptf: `
 transform "reorder_attributes" this {
   target_block_address = "resource.fake_resource.this"
-  tail_attributes      = ["lifecycle"]
+  foot_attributes      = ["lifecycle"]
 }
 `,
 			tfConfig: `
@@ -345,13 +345,13 @@ resource "fake_resource" this {
 `,
 		},
 		{
-			desc: "sort_middle_alphabetically_false_preserves_source_order",
+			desc: "sort_body_alphabetically_false_preserves_source_order",
 			mptf: `
 transform "reorder_attributes" this {
   target_block_address       = "resource.fake_resource.this"
   head_attributes            = ["count"]
-  tail_attributes            = ["depends_on"]
-  sort_middle_alphabetically = false
+  foot_attributes            = ["depends_on"]
+  sort_body_alphabetically = false
 }
 `,
 			tfConfig: `
@@ -381,11 +381,11 @@ resource "fake_resource" this {
 `,
 		},
 		{
-			desc: "sort_middle_alphabetically_false_still_inserts_nested_block_blank",
+			desc: "sort_body_alphabetically_false_still_inserts_nested_block_blank",
 			mptf: `
 transform "reorder_attributes" this {
   target_block_address       = "resource.fake_resource.this"
-  sort_middle_alphabetically = false
+  sort_body_alphabetically = false
 }
 `,
 			tfConfig: `
@@ -409,7 +409,7 @@ resource "fake_resource" this {
 `,
 		},
 		{
-			desc: "middle_only_no_head_no_tail_sorts_alphabetically_no_section_blanks",
+			desc: "body_only_no_head_no_foot_sorts_alphabetically_no_section_blanks",
 			mptf: `
 transform "reorder_attributes" this {
   target_block_address = "variable.example"
@@ -607,7 +607,7 @@ resource "fake_resource" this {
 transform "reorder_attributes" this {
   target_block_address       = "variable.example"
   head_attributes            = ["type"]
-  sort_middle_alphabetically = false
+  sort_body_alphabetically = false
 }
 `,
 			tfConfig: `
@@ -647,7 +647,7 @@ variable "example" {
 transform "reorder_attributes" this {
   target_block_address = "variable.example"
   head_attributes      = ["type", "validation"]
-  tail_attributes      = ["depends_on"]
+  foot_attributes      = ["depends_on"]
 }
 `,
 			tfConfig: `

--- a/pkg/transform_reorder_attributes_test.go
+++ b/pkg/transform_reorder_attributes_test.go
@@ -684,6 +684,186 @@ variable "example" {
 }
 `,
 		},
+		{
+			desc: "body_attributes_listed_first_unlisted_sorted_alphabetically",
+			mptf: `
+transform "reorder_attributes" this {
+  target_block_address = "resource.fake_resource.this"
+  body_attributes      = ["name", "location"]
+}
+`,
+			tfConfig: `
+resource "fake_resource" this {
+  tags     = {}
+  location = "westus"
+  name     = "rg"
+  sku      = "Standard"
+}
+`,
+			expected: `
+resource "fake_resource" this {
+  name     = "rg"
+  location = "westus"
+  sku      = "Standard"
+  tags     = {}
+}
+`,
+		},
+		{
+			desc: "body_attributes_with_sort_body_false_keeps_unlisted_in_source_order",
+			mptf: `
+transform "reorder_attributes" this {
+  target_block_address     = "resource.fake_resource.this"
+  body_attributes          = ["name", "location"]
+  sort_body_alphabetically = false
+}
+`,
+			tfConfig: `
+resource "fake_resource" this {
+  tags     = {}
+  location = "westus"
+  name     = "rg"
+  sku      = "Standard"
+}
+`,
+			expected: `
+resource "fake_resource" this {
+  name     = "rg"
+  location = "westus"
+  tags     = {}
+  sku      = "Standard"
+}
+`,
+		},
+		{
+			desc: "body_attributes_with_head_and_foot_three_section_flow",
+			mptf: `
+transform "reorder_attributes" this {
+  target_block_address = "resource.fake_resource.this"
+  head_attributes      = ["for_each", "count", "provider"]
+  body_attributes      = ["name", "location"]
+  foot_attributes      = ["lifecycle", "depends_on"]
+}
+`,
+			tfConfig: `
+resource "fake_resource" this {
+  depends_on = [other.thing]
+  tags       = {}
+  location   = "westus"
+  name       = "rg"
+  sku        = "Standard"
+  count      = 1
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+`,
+			expected: `
+resource "fake_resource" this {
+  count = 1
+
+  name     = "rg"
+  location = "westus"
+  sku      = "Standard"
+  tags     = {}
+
+  lifecycle {
+    create_before_destroy = true
+  }
+  depends_on = [other.thing]
+}
+`,
+		},
+		{
+			desc: "body_attributes_listed_nested_block_placed_before_unlisted",
+			mptf: `
+transform "reorder_attributes" this {
+  target_block_address = "variable.example"
+  head_attributes      = ["type"]
+  body_attributes      = ["validation"]
+}
+`,
+			tfConfig: `
+variable "example" {
+  description = "x"
+  type        = string
+  validation {
+    condition     = true
+    error_message = "first"
+  }
+  default = "v"
+}
+`,
+			expected: `
+variable "example" {
+  type = string
+
+  validation {
+    condition     = true
+    error_message = "first"
+  }
+  default     = "v"
+  description = "x"
+}
+`,
+		},
+		{
+			desc: "body_attributes_missing_names_silently_skipped",
+			mptf: `
+transform "reorder_attributes" this {
+  target_block_address = "variable.example"
+  body_attributes      = ["type", "default", "description", "nullable", "sensitive"]
+}
+`,
+			tfConfig: `
+variable "example" {
+  description = "x"
+  type        = string
+}
+`,
+			expected: `
+variable "example" {
+  type        = string
+  description = "x"
+}
+`,
+		},
+		{
+			desc: "body_head_overlap_returns_error",
+			mptf: `
+transform "reorder_attributes" this {
+  target_block_address = "variable.example"
+  head_attributes      = ["type"]
+  body_attributes      = ["type"]
+}
+`,
+			tfConfig: `
+variable "example" {
+  type = string
+}
+`,
+			expected:       ``,
+			wantErr:        true,
+			errorSubstring: "cannot be in both head_attributes and body_attributes",
+		},
+		{
+			desc: "body_foot_overlap_returns_error",
+			mptf: `
+transform "reorder_attributes" this {
+  target_block_address = "variable.example"
+  body_attributes      = ["type"]
+  foot_attributes      = ["type"]
+}
+`,
+			tfConfig: `
+variable "example" {
+  type = string
+}
+`,
+			expected:       ``,
+			wantErr:        true,
+			errorSubstring: "cannot be in both body_attributes and foot_attributes",
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
# v0.1.3: AddBlock structured insertion + ephemeral enumerator + schema-driven body ordering + head/body/foot rename

Bundled release combining the previously-staged v0.1.3 bug fix (#99) with the v0.1.4 schema-fetch feature work, now shipping as a single `v0.1.3` tag.

## Why one release

The governance migration (`Azure/avm-terraform-governance#472`) is the only known external consumer and is already coordinating its `MAPOTF_VERSION` bump in a single PR. Splitting into two mapotf releases would force two governance bumps for changes that land at the same time. One PR, one tag, one downstream bump.

## ⚠️ Breaking renames — head / body / foot

`reorder_attributes` parameters renamed to a coherent head/body/foot triple (HTML `thead`/`tbody`/`tfoot`). **No aliases, no deprecation period** — mapotf is pre-1.0 and the only known external consumer is updating in lockstep.

| v0.1.2 | v0.1.3 |
|---|---|
| `tail_attributes` | `foot_attributes` |
| `sort_middle_alphabetically` | `sort_body_alphabetically` |
| `head_tail_line_breaks` | `head_foot_line_breaks` |

Migration is a mechanical sweep — every callsite in your `.mptf.hcl` files needs the new names.

## Bug fix: AddBlock structured insertion

Composing `move_block` + `sort_blocks_in_file` on the same address used to produce orphan duplicate blocks. Root cause: `Module.AddBlock` inserted blocks via `AppendUnstructuredTokens(block.BuildTokens(nil))`, which is invisible to `body.Blocks()` walks used by `RemoveBlock`. Latent for AVM-conformant modules but tripped immediately for any caller that composed the two transforms.

Fix: `AddBlock` now uses `Body().AppendBlock(block)` (structured insertion), and `move_block` swaps from `AddBlock → RemoveBlock` to `RemoveBlock → AddBlock` since `AppendBlock` has no copy semantics. Pinned by two new round-trip regression tests in `pkg/terraform/module_test.go`.

## New: `data "ephemeral"`

Enumerator for Terraform 1.10+ ephemeral resources, structurally identical to `data "data"`. Address format `ephemeral.<type>.<name>`. Filters: `ephemeral_type`, `use_count`, `use_for_each`. Lets governance configs extend meta-arg ordering (`for_each`/`count`/`provider` at top, `lifecycle`/`depends_on` at bottom) to cover ephemeral resources alongside resources and data sources.

## New: `reorder_attributes.body_attributes`

A third optional list parameter parallel to `head_attributes` and `foot_attributes` that pins the order of attributes/nested blocks in the body section. Listed names land first in the given order; unlisted attrs follow per `sort_body_alphabetically` (default `true`).

```hcl
transform "reorder_attributes" "resource_body" {
  target_block_address = "resource.azurerm_resource_group.this"
  head_attributes      = ["for_each", "count", "provider"]
  body_attributes      = ["location", "name", "tags"]
  foot_attributes      = ["lifecycle", "depends_on"]
}
```

Names appearing in more than one of head/body/foot are a configuration error. Names not present on the block are silently skipped.

## New: `data "provider_schema"` sorted attribute lists + `data_sources`

Four new pre-sorted attributes that feed `body_attributes` directly:

- `resources_required_attributes` — `map<type, sorted list<string>>`
- `resources_optional_attributes` — `map<type, sorted list<string>>` (excludes computed-only)
- `data_sources_required_attributes` / `data_sources_optional_attributes` — same shape for data sources

Plus a new `data_sources` attribute (full schema, parallel to existing `resources`).

```hcl
data "provider_schema" "azurerm" {
  provider_source  = "hashicorp/azurerm"
  provider_version = "~> 4.0"
}

transform "reorder_attributes" "rg_body" {
  target_block_address = "resource.azurerm_resource_group.this"
  head_attributes      = ["for_each", "count", "provider"]
  body_attributes      = concat(
    try(data.provider_schema.azurerm.resources_required_attributes["azurerm_resource_group"], []),
    try(data.provider_schema.azurerm.resources_optional_attributes["azurerm_resource_group"], []),
  )
  foot_attributes      = ["lifecycle", "depends_on"]
}
```

## New: `data "module_source"`

Closes deferred item #14 from the original avmfix-replacement plan — module input required-before-optional ordering for `module "x" {}` block bodies.

Fetches a Terraform module (registry, git, etc.) via `terraform get` in a temp folder and exposes its variables + outputs via `terraform-config-inspect`:

```hcl
data "module_source" "naming" {
  source  = "Azure/naming/azurerm"
  version = "~> 0.4"
}

transform "reorder_attributes" "naming_module" {
  target_block_address = "module.naming"
  head_attributes      = ["source", "version", "providers", "for_each", "count"]
  body_attributes      = concat(
    data.module_source.naming.required_variables,
    data.module_source.naming.optional_variables,
  )
  foot_attributes      = ["depends_on"]
}
```

Exposed attributes:

- `variables` — `map<name, {required, type, description, sensitive, default}>`
- `outputs` — `map<name, {description, sensitive}>`
- `required_variables` / `optional_variables` — sorted `list<string>`

Uses `tf.Get(ctx)` (modules only, no provider plugin fetch) so it's faster than `data "provider_schema"` and works without provider credentials. Per-invocation cache means the same `(source, version)` is fetched at most once per `mapotf transform` run.

## Why a list, not a `sort_body = "schema"` enum

`reorder_attributes` is a pure HCL composition primitive — it knows nothing about provider schemas or module sources, only `target_block_address` + lists of strings. A `sort_body = "schema"` enum would couple the transform to a specific data source by name. Keeping the schema lookup in HCL means the same shape works for any source of truth: provider schemas, module source variables, or hand-curated lists.

## Out of scope (future considerations)

- **Multi-group head/foot** (e.g. `head_groups = [[...]]`): rejected — YAGNI, avmfix doesn't do it. If a real need emerges later, `head_attributes = [...]` becomes sugar for `head_groups = [[...]]` — non-breaking and additive.
- **Schema-driven nested block ordering inside the body:** `body_attributes` already accepts nested-block addresses, but there's no provider-schema source of truth for nested-block ordering yet.

## New dependency

`github.com/hashicorp/terraform-config-inspect/tfconfig` — small, single-purpose, official HashiCorp library used widely (avmfix, tflint, terraform-docs).

## Verification

- ✅ `go test ./... -count=1` — all packages pass on ubuntu + windows
- ✅ `golangci-lint v2.4.0-alpine --timeout=5m ./...` — 0 issues

## Replaces

- Closes #99 (consolidated into this PR)

## Governance follow-up

The complementary PR in `Azure/avm-terraform-governance` will:

1. Bump `MAPOTF_VERSION` to `v0.1.3`.
2. Sweep every `tail_attributes` / `sort_middle_alphabetically` / `head_tail_line_breaks` callsite in `mapotf-configs/**.mptf.hcl` to the new foot/body names.
3. Add an `ephemeral.*.for_order` block to `order_resource_meta.mptf.hcl`.
4. Add `order_resource_attrs.mptf.hcl` using `data.provider_schema.<x>.resources_required/optional_attributes` for schema-driven body ordering across `azurerm_*` resources.
5. Optionally add `order_module_attrs.mptf.hcl` using `data "module_source"` for the most-used modules (e.g. `Azure/naming/azurerm`).

All ships in one governance PR after `v0.1.3` is tagged.