### PR TITLE
feat(terraform/eval)!: decode literal attribute expressions to typed cty values (v0.1.4)

### DIFF
--- a/doc/d/output.md
+++ b/doc/d/output.md
@@ -1,6 +1,8 @@
 # Data "output" Block
 
-The `data "output"` block enumerates `output` blocks in the target Terraform configuration. Each result entry is the output block's full evaluation context — its attribute values (stringified) plus an `mptf` metadata sub-object that includes the block's source file and range.
+The `data "output"` block enumerates `output` blocks in the target Terraform configuration. Each result entry is the output block's full evaluation context — its attribute values plus an `mptf` metadata sub-object that includes the block's source file and range.
+
+Literal attribute values (string, number, bool, list, object) are decoded to their typed `cty` form, so HCL like `sensitive = false` exposes `each.value.sensitive` as the bool `false`. Attribute values that reference variables, locals, or resource attributes cannot be evaluated at config-load time and fall back to the literal token text — for example `value = azurerm_resource_group.this.id` exposes `each.value.value` as the string `"azurerm_resource_group.this.id"`.
 
 ## Arguments
 
@@ -42,7 +44,7 @@ output "name" {
 data "output" "all" {}
 
 transform "remove_block_element" "drop_output_sensitive_false" {
-  for_each             = { for n, v in data.output.all.result : n => v if try(v.sensitive, "") == "false" }
+  for_each             = { for n, v in data.output.all.result : n => v if try(v.sensitive, true) == false }
   target_block_address = "output.${each.key}"
   paths                = ["sensitive"]
 }
@@ -69,4 +71,4 @@ This is the canonical AVM pre-commit rule for outputs — every `output` block e
 
 - The result is a map keyed by output name, so for any given module each output appears at most once.
 - The `mptf.range.file_name` field of each entry is useful for filtering blocks by source file (for example "every output currently in `main.tf` should move to `outputs.tf`").
-- All attribute values are returned as their string representation. The `value` attribute, in particular, is returned as its literal HCL expression text — `value = azurerm_resource_group.this.id` shows up as the string `"azurerm_resource_group.this.id"`.
+- All attribute values are decoded to their typed `cty` form whenever the expression is a literal (string, number, bool, list, object). Bool attributes like `sensitive = false` surface as the bool `false`. Expressions that reference variables, locals, resource attributes, or functions cannot be evaluated at config-load time and fall back to the literal token text — `value = azurerm_resource_group.this.id`, for example, surfaces as the string `"azurerm_resource_group.this.id"`.

--- a/doc/d/variable.md
+++ b/doc/d/variable.md
@@ -1,6 +1,8 @@
 # Data "variable" Block
 
-The `data "variable"` block enumerates `variable` blocks in the target Terraform configuration. Each result entry is the variable block's full evaluation context — its attribute values (stringified) plus an `mptf` metadata sub-object that includes the block's source file and range.
+The `data "variable"` block enumerates `variable` blocks in the target Terraform configuration. Each result entry is the variable block's full evaluation context — its attribute values plus an `mptf` metadata sub-object that includes the block's source file and range.
+
+Literal attribute values (string, number, bool, list, object) are decoded to their typed `cty` form, so HCL like `default = 5` exposes `each.value.default` as the number `5` and `nullable = true` as the bool `true`. Attribute values that reference variables, locals, functions, or `each.*` cannot be evaluated at config-load time and fall back to the literal token text — for example `default = var.something` exposes `each.value.default` as the string `"var.something"`. The `type` attribute is almost always a bare type expression (`string`, `map(string)`, ...) so it usually surfaces as its token text.
 
 ## Arguments
 
@@ -57,13 +59,13 @@ locals {
 data "variable" "all" {}
 
 transform "remove_block_element" "drop_nullable_true" {
-  for_each             = { for n, v in data.variable.all.result : n => v if try(v.nullable, "") == "true" }
+  for_each             = { for n, v in data.variable.all.result : n => v if try(v.nullable, false) == true }
   target_block_address = "variable.${each.key}"
   paths                = ["nullable"]
 }
 ```
 
-The `try(v.nullable, "")` guard handles variables that don't declare `nullable` at all.
+The `try(v.nullable, false)` guard handles variables that don't declare `nullable` at all by defaulting to `false`, so the filter only fires on `nullable = true`.
 
 ## Example - Look up a single variable
 
@@ -79,4 +81,4 @@ data "variable" "location" {
 
 - The result is a map keyed by variable name, so for any given module each variable appears at most once.
 - The `mptf.range.file_name` field of each entry is useful for filtering blocks by source file (for example "every variable currently in `main.tf` should move to `variables.tf`").
-- All attribute values are returned as their string representation. Numeric defaults like `default = 5` show up as the string `"5"`; type expressions like `type = string` show up as the string `"string"`; complex defaults like `default = { a = 1 }` show up as the literal text of the expression.
+- All attribute values are decoded to their typed `cty` form whenever the expression is a literal (string, number, bool, list, object, heredoc without interpolation). Numeric defaults like `default = 5` surface as the number `5`; bool defaults like `nullable = true` surface as the bool `true`; complex defaults like `default = { a = 1 }` surface as an object you can index (for example `each.value.default.a`). Expressions that reference variables, locals, functions, or iterators cannot be evaluated at config-load time and fall back to the literal token text — for example `default = var.something` surfaces as the string `"var.something"`. The `type` attribute is almost always a bare type expression (`type = string`) and surfaces as its token text (`"string"`).

--- a/pkg/data_data_source_test.go
+++ b/pkg/data_data_source_test.go
@@ -31,7 +31,7 @@ func TestDataSourceData_QueryDataBlocks(t *testing.T) {
 			expected: cty.ObjectVal(map[string]cty.Value{
 				"fake_data": cty.ObjectVal(map[string]cty.Value{
 					"this": cty.ObjectVal(map[string]cty.Value{
-						"id": cty.StringVal("123"),
+						"id": cty.NumberIntVal(123),
 					}),
 				}),
 			}),
@@ -48,7 +48,7 @@ data "fake_data" that {
 			expected: cty.ObjectVal(map[string]cty.Value{
 				"fake_data": cty.ObjectVal(map[string]cty.Value{
 					"that": cty.ObjectVal(map[string]cty.Value{
-						"count": cty.StringVal("2"),
+						"count": cty.NumberIntVal(2),
 					}),
 				}),
 			}),
@@ -102,7 +102,7 @@ data "fake_data" that {
 				"use_for_each":     cty.BoolVal(c.useForEach),
 				"result":           c.expected,
 			}
-			assert.Equal(t, expected, result)
+			assertCtyMapRawEquals(t, expected, result)
 		})
 	}
 }

--- a/pkg/data_ephemeral_test.go
+++ b/pkg/data_ephemeral_test.go
@@ -31,7 +31,7 @@ func TestEphemeralData_QueryEphemeralBlocks(t *testing.T) {
 			expected: cty.ObjectVal(map[string]cty.Value{
 				"fake_ephemeral": cty.ObjectVal(map[string]cty.Value{
 					"this": cty.ObjectVal(map[string]cty.Value{
-						"id": cty.StringVal("123"),
+						"id": cty.NumberIntVal(123),
 					}),
 				}),
 			}),
@@ -48,7 +48,7 @@ ephemeral "fake_ephemeral" that {
 			expected: cty.ObjectVal(map[string]cty.Value{
 				"fake_ephemeral": cty.ObjectVal(map[string]cty.Value{
 					"that": cty.ObjectVal(map[string]cty.Value{
-						"count": cty.StringVal("2"),
+						"count": cty.NumberIntVal(2),
 					}),
 				}),
 			}),
@@ -101,7 +101,7 @@ ephemeral "fake_ephemeral" that {
 				"use_for_each":   cty.BoolVal(c.useForEach),
 				"result":         c.expected,
 			}
-			assert.Equal(t, expected, result)
+			assertCtyMapRawEquals(t, expected, result)
 		})
 	}
 }

--- a/pkg/data_module_test.go
+++ b/pkg/data_module_test.go
@@ -31,8 +31,8 @@ module "naming" {
 }`,
 			expectedModuleName: "naming",
 			expectedAttrs: map[string]cty.Value{
-				"source":  cty.StringVal(`"./modules/naming"`),
-				"version": cty.StringVal(`"1.0.0"`),
+				"source":  cty.StringVal(`./modules/naming`),
+				"version": cty.StringVal(`1.0.0`),
 			},
 		},
 		{
@@ -49,7 +49,7 @@ module "second" {
 			moduleName:         "second",
 			expectedModuleName: "second",
 			expectedAttrs: map[string]cty.Value{
-				"source": cty.StringVal(`"./modules/second"`),
+				"source": cty.StringVal(`./modules/second`),
 			},
 		},
 		{

--- a/pkg/data_output_test.go
+++ b/pkg/data_output_test.go
@@ -28,7 +28,7 @@ output "example_output" {
   value = "example_value"
 }`,
 			expectedOutputName: "example_output",
-			expectedValue:      cty.StringVal(`"example_value"`),
+			expectedValue:      cty.StringVal(`example_value`),
 		},
 		{
 			desc: "filter by output name",
@@ -41,7 +41,7 @@ output "example_output" {
 		 value = "value_two"
 		}`,
 			expectedOutputName: "output_two",
-			expectedValue:      cty.StringVal(`"value_two"`),
+			expectedValue:      cty.StringVal(`value_two`),
 		},
 		{
 			desc: "no matching output",

--- a/pkg/data_resource_test.go
+++ b/pkg/data_resource_test.go
@@ -31,7 +31,7 @@ func TestResourceData_QueryResourceBlocks(t *testing.T) {
 			expected: cty.ObjectVal(map[string]cty.Value{
 				"fake_resource": cty.ObjectVal(map[string]cty.Value{
 					"this": cty.ObjectVal(map[string]cty.Value{
-						"id": cty.StringVal("123"),
+						"id": cty.NumberIntVal(123),
 					}),
 				}),
 			}),
@@ -48,7 +48,7 @@ resource "fake_resource" that {
 			expected: cty.ObjectVal(map[string]cty.Value{
 				"fake_resource": cty.ObjectVal(map[string]cty.Value{
 					"that": cty.ObjectVal(map[string]cty.Value{
-						"count": cty.StringVal("2"),
+						"count": cty.NumberIntVal(2),
 					}),
 				}),
 			}),
@@ -102,7 +102,7 @@ resource "fake_resource" that {
 				"use_for_each":  cty.BoolVal(c.useForEach),
 				"result":        c.expected,
 			}
-			assert.Equal(t, expected, result)
+			assertCtyMapRawEquals(t, expected, result)
 		})
 	}
 }

--- a/pkg/data_variable_test.go
+++ b/pkg/data_variable_test.go
@@ -33,7 +33,7 @@ variable "example_var" {
 			expectedVariableName: "example_var",
 			expectedAttributes: map[string]cty.Value{
 				"type":    cty.StringVal("string"),
-				"default": cty.StringVal(`"value"`),
+				"default": cty.StringVal(`value`),
 			},
 		},
 		{
@@ -53,7 +53,7 @@ variable "example_var" {
 			expectedVariableName: "my_var",
 			expectedAttributes: map[string]cty.Value{
 				"type":    cty.StringVal("string"),
-				"default": cty.StringVal(`"hello"`),
+				"default": cty.StringVal(`hello`),
 			},
 		},
 		{

--- a/pkg/mptf_config_test.go
+++ b/pkg/mptf_config_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestNewMetaProgrammingTFConfigShouldLoadTerraformBlocks(t *testing.T) {
@@ -129,4 +130,19 @@ func fakeFs(files map[string]string) afero.Fs {
 		_ = afero.WriteFile(fs, n, []byte(content), 0644)
 	}
 	return fs
+}
+
+// assertCtyMapRawEquals compares two maps of cty.Value using cty's RawEquals
+// semantics. testify's assert.Equal does a deep struct compare on cty.Value's
+// internal big.Float, which fails when one side was constructed via
+// cty.NumberIntVal (prec 64) and the other via hcl Expr.Value() (prec 512),
+// even though both represent the same number. RawEquals uses big.Float.Cmp,
+// which ignores precision differences.
+func assertCtyMapRawEquals(t *testing.T, expected, actual map[string]cty.Value) {
+	t.Helper()
+	e := cty.ObjectVal(expected)
+	a := cty.ObjectVal(actual)
+	if !e.RawEquals(a) {
+		t.Errorf("cty maps differ\nexpected: %s\n  actual: %s", e.GoString(), a.GoString())
+	}
 }

--- a/pkg/terraform/nested_block.go
+++ b/pkg/terraform/nested_block.go
@@ -90,13 +90,13 @@ func NewNestedBlock(rb *hclsyntax.Block, wb *hclwrite.Block) *NestedBlock {
 func (nb *NestedBlock) EvalContext() cty.Value {
 	v := map[string]cty.Value{}
 	for n, a := range nb.Attributes {
-		v[n] = cty.StringVal(a.String())
+		v[n] = evalAttributeValue(a)
 	}
 	if nb.ForEach != nil {
-		v["for_each"] = cty.StringVal(nb.ForEach.String())
+		v["for_each"] = evalAttributeValue(nb.ForEach)
 	}
 	if nb.Iterator != nil {
-		v["iterator"] = cty.StringVal(nb.Iterator.String())
+		v["iterator"] = evalAttributeValue(nb.Iterator)
 	}
 	for k, nbv := range nb.NestedBlocks.Values() {
 		v[k] = nbv

--- a/pkg/terraform/nested_block_test.go
+++ b/pkg/terraform/nested_block_test.go
@@ -211,7 +211,7 @@ resource "fake_resource" this {
 	require.Falsef(t, diag.HasErrors(), diag.Error())
 	value, diag := exp.Value(ctx)
 	require.Falsef(t, diag.HasErrors(), diag.Error())
-	assert.Equal(t, `"John"`, value.AsString())
+	assert.Equal(t, `John`, value.AsString())
 }
 
 func TestNestedBlock_RemoveNestedBlock(t *testing.T) {

--- a/pkg/terraform/root_block.go
+++ b/pkg/terraform/root_block.go
@@ -161,18 +161,36 @@ func (b *RootBlock) EvalContext() cty.Value {
 	v := map[string]cty.Value{}
 	RootBlockReflectionInformation(v, b)
 	for n, a := range b.Attributes {
-		v[n] = cty.StringVal(a.String())
+		v[n] = evalAttributeValue(a)
 	}
 	if b.Count != nil {
-		v["count"] = cty.StringVal(b.Count.String())
+		v["count"] = evalAttributeValue(b.Count)
 	}
 	if b.ForEach != nil {
-		v["for_each"] = cty.StringVal(b.ForEach.String())
+		v["for_each"] = evalAttributeValue(b.ForEach)
 	}
 	for k, values := range b.NestedBlocks.Values() {
 		v[k] = values
 	}
 	return cty.ObjectVal(v)
+}
+
+// evalAttributeValue tries to decode the attribute's expression as a literal cty
+// value (string, number, bool, list, object, etc.) so callers see typed values
+// for literal HCL like `name = "foo"` or `count = 3`. Expressions that reference
+// variables, locals, functions, or `each.*` fall back to the attribute's raw
+// token text (the historical mapotf behaviour) so existing comparisons against
+// the rendered token bytes still work for expression attributes.
+func evalAttributeValue(a *Attribute) cty.Value {
+	if a == nil {
+		return cty.NullVal(cty.String)
+	}
+	if a.Expr != nil {
+		if val, diag := a.Expr.Value(nil); !diag.HasErrors() {
+			return val
+		}
+	}
+	return cty.StringVal(a.String())
 }
 
 func attributes(rb *hclsyntax.Body, wb *hclwrite.Body) map[string]*Attribute {

--- a/pkg/terraform/root_block_test.go
+++ b/pkg/terraform/root_block_test.go
@@ -111,17 +111,17 @@ func TestBlockAddressGetValue(t *testing.T) {
 		{
 			desc:     "root attribute",
 			path:     "name",
-			expected: `"example-aks1"`,
+			expected: `example-aks1`,
 		},
 		{
 			desc:     "nested block's attribute",
 			path:     "default_node_pool.0.name",
-			expected: `"default"`,
+			expected: `default`,
 		},
 		{
 			desc:     "nested block's attribute, bracket syntax",
 			path:     "default_node_pool[0].name",
-			expected: `"default"`,
+			expected: `default`,
 		},
 		{
 			desc:     "dynamic block's for_each",
@@ -144,11 +144,9 @@ func TestBlockAddressGetValue(t *testing.T) {
 			expected: "var.user_assigned_identity_id",
 		},
 		{
-			desc: "tags",
-			path: "tags",
-			expected: `{
-    Environment = "Production"
-  }`,
+			desc:     "object literal attribute is decoded",
+			path:     "tags.Environment",
+			expected: `Production`,
 		},
 	}
 	for _, cc := range cases {
@@ -250,9 +248,9 @@ resource "fake_resource" that {
 		},
 	}
 	v := expressionValue(t, "result.0.top_block.0.second_block.0.id", ctx)
-	assert.Equal(t, "123", v.AsString())
+	assert.True(t, cty.NumberIntVal(123).RawEquals(v), "expected 123, got %s", v.GoString())
 	v = expressionValue(t, "result.1.top_block.0.third_block.0.name", ctx)
-	assert.Equal(t, `"John"`, v.AsString())
+	assert.Equal(t, `John`, v.AsString())
 }
 
 func TestRootBlock_RemoveDeepNestedBlock(t *testing.T) {


### PR DESCRIPTION
## What

Decode literal attribute expressions in `RootBlock.EvalContext` and `NestedBlock.EvalContext` to typed `cty` values instead of wrapping every value as raw token-text via `cty.StringVal(attr.String())`.

Closes #103 (G4 module-input ordering needs `data.module.X.source` to evaluate to `"./mod"`, not `"\"./mod\""`).

## Why

Today, `data.module.foo.result.foo.source` evaluates to the string literally containing the quote chars: `"\"./mod\""`. Consumers have to strip the embedded quotes with `trim(v.source, "\"")` and the same workaround is needed for numbers (`"5"` instead of `5`) and bools (`"true"` instead of `true`). This breaks the conventional Terraform expectation and blocks any clean composition of `data.module` / `data.module_source` / `data.variable` results into `reorder_attributes.body_attributes`.

## How

New helper `evalAttributeValue(*Attribute) cty.Value` lives in `pkg/terraform/root_block.go` and is shared by both `RootBlock.EvalContext` and `NestedBlock.EvalContext` (same package). It calls `Expr.Value(nil)` -- with a nil `EvalContext`, only literal expressions evaluate cleanly:

- Literals (strings, numbers, bools, lists, objects, heredocs without interpolation) → typed cty value.
- References (`var.*`, `local.*`, `each.*`, type identifiers like `type = string`, function calls like `toset([1,2,3])`) return diagnostics → fall through to the historical `cty.StringVal(a.String())` token-text fallback.

## :rotating_light: Breaking change

Any `.mptf.hcl` config that compared literal attribute values against quoted-string fixtures must be migrated. mapotf is pre-1.0 and the only known consumer (`Azure/avm-terraform-governance`) is migrating in lockstep.

| Old comparison (v0.1.3) | New comparison (v0.1.4) |
|---|---|
| `v.source == "\"./mod\""` | `v.source == "./mod"` |
| `v.nullable == "true"` | `v.nullable == true` |
| `v.sensitive == "false"` | `v.sensitive == false` |
| `v.default == "5"` | `v.default == 5` |
| `v.default == "{}"` | use `length(v.default) == 0` against the decoded object |

Reference-bearing expressions (`var.X`, `each.value.X`, `type = string`) are **unchanged** -- they still evaluate to their raw token text exactly as in v0.1.3.

Heredoc behaviour: `<<EOT\nhello\nEOT` was raw token bytes; now decodes to `"hello\n"` when there's no interpolation. Interpolated heredocs still fall through to token text.

## Files changed

- `pkg/terraform/root_block.go` -- `EvalContext` body, Count, ForEach use the new helper; helper appended.
- `pkg/terraform/nested_block.go` -- `EvalContext` body, ForEach, Iterator use the helper.
- `pkg/terraform/{root,nested}_block_test.go` -- fixtures stripped of embedded quotes; numeric fixtures use `cty.NumberIntVal`.
- `pkg/data_{resource,data_source,ephemeral,module,output,variable}_test.go` -- fixtures stripped; numeric fixtures use `cty.NumberIntVal`; the three biggest comparisons use a new `assertCtyMapRawEquals` helper.
- `pkg/mptf_config_test.go` -- hosts the new `assertCtyMapRawEquals` helper (uses `cty.Value.RawEquals` to ignore `big.Float` precision differences between `cty.NumberIntVal(123)` and `Expr.Value(nil)`-decoded numbers).
- `doc/d/variable.md`, `doc/d/output.md` -- rewritten to reflect typed-value evaluation, with literal-vs-reference prose and updated `try(v.nullable, false)` / `try(v.sensitive, true) == false` examples.

## Verification

- `go build ./...` -- clean.
- `go test ./... -count=1` -- all packages pass.
- `golangci-lint v2.4.0-alpine --timeout=5m ./...` -- 0 issues.

## Release plan

This is the first commit for `v0.1.4`. The other planned v0.1.4 items (#101 provider-schema namespace casing, #102 reorder_attributes collision detection) ship in separate PRs against the same `v0.1.4` tag.