### PR TITLE
fix(data/module_source): support local sources and tolerate terraform get validation (v0.1.4)

### DIFF
--- a/doc/d/module_source.md
+++ b/doc/d/module_source.md
@@ -6,6 +6,7 @@ The `module_source` data source fetches a remote Terraform module by its `source
 
 - `source` (String, Required): The module source, exactly as you would write it in a `module { source = "..." }` block — for example `Azure/naming/azurerm`, `git::https://github.com/Azure/terraform-azurerm-aks.git?ref=v9.0.0`, or `./modules/storage`.
 - `version` (String, Optional): A version constraint, only meaningful for sources that support versioning (e.g. registry sources). Same syntax as the `version` argument of a `module` block — for example `~> 0.4`.
+- `base_dir` (String, Optional): Directory used to resolve a relative `source` (e.g. `./submod`, `../shared`). When omitted, defaults to the absolute path of the Terraform module mapotf is currently transforming — so a `data "module_source" { source = "../../" }` in `mapotf-configs/*.mptf.hcl` resolves to the same parent module Terraform itself would resolve. Ignored for remote sources (registry shortcuts, Git URLs).
 
 ## Attributes
 
@@ -79,8 +80,9 @@ For a multi-source repository, branch on `data.module.all.result[each.key].sourc
 
 ## Under the Hood
 
-Mapotf synthesises a minimal Terraform configuration that calls the requested module in a temporary directory, runs `terraform get` to fetch the module source, then loads the fetched module with `terraform-config-inspect` to read its variable and output declarations.
+Mapotf parses the requested module in one of two ways depending on the source:
 
-`terraform get` fetches the module only — it does **not** download provider plugins. This makes `data "module_source"` faster than `data "provider_schema"` and means it works without provider credentials.
+- **Local sources** (`./`, `../`, absolute paths): resolved against `base_dir` and parsed directly with `terraform-config-inspect`. No `terraform` invocation, no temp folder, no network. This is the path AVM modules' `examples/*` configurations use to point at the parent module under test via `source = "../../"`.
+- **Remote sources** (registry shortcuts, Git URLs, etc.): mapotf synthesises a minimal Terraform configuration that calls the requested module in a temporary directory, runs `terraform get` to fetch the module source, then loads the fetched module with `terraform-config-inspect` to read its variable and output declarations. `terraform get` fetches the module only — it does **not** download provider plugins, so `data "module_source"` is faster than `data "provider_schema"` and works without provider credentials. If `terraform get` reports validation errors (e.g. the synthetic wrapper doesn't satisfy the target module's required inputs) but the module body itself was downloaded successfully, mapotf ignores the validation error and reads the downloaded `.tf` files anyway, because `terraform-config-inspect` only needs the module's declarations, not a fully-validated wrapper.
 
-Each unique `(source, version)` pair is fetched at most once per `mapotf transform` run.
+Each unique `(source, version, base_dir)` triple is fetched at most once per `mapotf transform` run.

--- a/pkg/data_module_source.go
+++ b/pkg/data_module_source.go
@@ -19,18 +19,25 @@ var ModuleSourceFetcherFactory = func(ctx context.Context) TerraformModuleSource
 	return NewTerraformCliModuleSourceFetcher(ctx)
 }
 
-// ModuleSourceData fetches the variables and outputs of a remote Terraform
-// module (by `source` + optional `version`) using `terraform get` and exposes
-// them as cty values that downstream transforms can compose against. The
-// pre-sorted `required_variables` / `optional_variables` lists are intended to
-// be fed into `reorder_attributes.body_attributes` so a `module.<name>` block's
+// ModuleSourceData fetches the variables and outputs of a Terraform module
+// (by `source` + optional `version`) and exposes them as cty values that
+// downstream transforms can compose against. The pre-sorted
+// `required_variables` / `optional_variables` lists are intended to be fed
+// into `reorder_attributes.body_attributes` so a `module.<name>` block's
 // inputs end up in required-then-optional alphabetical order.
+//
+// `source` accepts the same values you'd write in a `module { source = "..." }`
+// block: registry shortcuts (`Azure/naming/azurerm`), git URLs, and local
+// paths (`./submod`, `../../`, absolute paths). Local paths are resolved
+// against `base_dir`, which defaults to the target Terraform module's
+// directory so callers normally don't need to set it.
 type ModuleSourceData struct {
 	*BaseData
 	*golden.BaseBlock
 
 	Source            string    `hcl:"source"`
 	Version           string    `hcl:"version,optional"`
+	BaseDir           string    `hcl:"base_dir,optional"`
 	Variables         cty.Value `attribute:"variables"`
 	Outputs           cty.Value `attribute:"outputs"`
 	RequiredVariables cty.Value `attribute:"required_variables"`
@@ -42,7 +49,13 @@ func (d *ModuleSourceData) Type() string {
 }
 
 func (d *ModuleSourceData) ExecuteDuringPlan() error {
-	mod, err := ModuleSourceFetcherFactory(d.Context()).Get(d.Source, d.Version)
+	baseDir := d.BaseDir
+	if baseDir == "" && d.BaseBlock != nil {
+		if cfg, ok := d.Config().(*MetaProgrammingTFConfig); ok {
+			baseDir = cfg.ModuleDir()
+		}
+	}
+	mod, err := ModuleSourceFetcherFactory(d.Context()).Get(d.Source, d.Version, baseDir)
 	if err != nil {
 		return fmt.Errorf("cannot fetch module source %q version %q: %w", d.Source, d.Version, err)
 	}
@@ -121,6 +134,7 @@ func (d *ModuleSourceData) String() string {
 	data := cty.ObjectVal(map[string]cty.Value{
 		"source":             cty.StringVal(d.Source),
 		"version":            cty.StringVal(d.Version),
+		"base_dir":           cty.StringVal(d.BaseDir),
 		"variables":          d.Variables,
 		"outputs":            d.Outputs,
 		"required_variables": d.RequiredVariables,

--- a/pkg/data_module_source_test.go
+++ b/pkg/data_module_source_test.go
@@ -16,9 +16,18 @@ import (
 type stubModuleSourceFetcher struct {
 	mod *tfconfig.Module
 	err error
+	// capture call args so tests can assert what the data block passed in
+	calls []moduleSourceFetcherCall
 }
 
-func (s *stubModuleSourceFetcher) Get(source, version string) (*tfconfig.Module, error) {
+type moduleSourceFetcherCall struct {
+	source  string
+	version string
+	baseDir string
+}
+
+func (s *stubModuleSourceFetcher) Get(source, version, baseDir string) (*tfconfig.Module, error) {
+	s.calls = append(s.calls, moduleSourceFetcherCall{source: source, version: version, baseDir: baseDir})
 	return s.mod, s.err
 }
 
@@ -147,6 +156,7 @@ func TestDataModuleSource_StringJSONShape(t *testing.T) {
 
 	assert.Equal(t, "Azure/naming/azurerm", got["source"])
 	assert.Equal(t, "~> 0.4", got["version"])
+	assert.Equal(t, "", got["base_dir"])
 	require.Contains(t, got, "variables")
 	require.Contains(t, got, "outputs")
 	require.Contains(t, got, "required_variables")
@@ -203,4 +213,85 @@ func TestDataModuleSource_EmptyModule(t *testing.T) {
 	// downstream `concat(required_variables, optional_variables)` keeps working.
 	assert.True(t, d.RequiredVariables.LengthInt() == 0)
 	assert.True(t, d.OptionalVariables.LengthInt() == 0)
+}
+
+// TestDataModuleSource_BaseDirAutoDefaultsToModuleDir pins the behaviour that
+// makes the common AVM case "just work": when a `.mptf.hcl` config writes
+// `data "module_source" { source = "./submod" }` without spelling out
+// `base_dir`, the data block defaults `base_dir` to the target module's
+// AbsDir so the relative source resolves against the caller's module, not
+// against an internal mapotf temp folder.
+func TestDataModuleSource_BaseDirAutoDefaultsToModuleDir(t *testing.T) {
+	fetcher := &stubModuleSourceFetcher{mod: &tfconfig.Module{
+		Variables: map[string]*tfconfig.Variable{
+			"name": {Name: "name", Required: true},
+		},
+		Outputs: map[string]*tfconfig.Output{},
+	}}
+	stub := gostub.Stub(&pkg.ModuleSourceFetcherFactory, func(ctx context.Context) pkg.TerraformModuleSourceFetcher {
+		return fetcher
+	}).Stub(&filesystem.Fs, fakeFs(map[string]string{
+		"/main.tf": `resource "azurerm_resource_group" this {
+}
+`,
+	}))
+	defer stub.Reset()
+
+	hclBlocks := newHclBlocks(t, `
+data "module_source" "local" {
+  source = "./submod"
+}
+`)
+	cfg, err := pkg.NewMetaProgrammingTFConfig(&pkg.TerraformModuleRef{
+		Dir:    ".",
+		AbsDir: "/",
+	}, nil, nil, nil, context.TODO())
+	require.NoError(t, err)
+	require.NoError(t, cfg.Init(hclBlocks))
+	require.NoError(t, cfg.RunPrePlan())
+	require.NoError(t, cfg.RunPlan())
+
+	require.Len(t, fetcher.calls, 1, "expected exactly one fetcher invocation")
+	call := fetcher.calls[0]
+	assert.Equal(t, "./submod", call.source)
+	assert.Equal(t, "", call.version)
+	assert.Equal(t, "/", call.baseDir,
+		"base_dir should auto-default to the target module's AbsDir when not explicitly set")
+}
+
+// TestDataModuleSource_BaseDirExplicitOverride pins that an explicit
+// `base_dir = "..."` in the HCL wins over the auto-default. This lets
+// advanced configs target a sibling directory or a synthesised fixture path.
+func TestDataModuleSource_BaseDirExplicitOverride(t *testing.T) {
+	fetcher := &stubModuleSourceFetcher{mod: &tfconfig.Module{
+		Variables: map[string]*tfconfig.Variable{},
+		Outputs:   map[string]*tfconfig.Output{},
+	}}
+	stub := gostub.Stub(&pkg.ModuleSourceFetcherFactory, func(ctx context.Context) pkg.TerraformModuleSourceFetcher {
+		return fetcher
+	}).Stub(&filesystem.Fs, fakeFs(map[string]string{
+		"/main.tf": `resource "azurerm_resource_group" this {
+}
+`,
+	}))
+	defer stub.Reset()
+
+	hclBlocks := newHclBlocks(t, `
+data "module_source" "local" {
+  source   = "./submod"
+  base_dir = "/explicit/override"
+}
+`)
+	cfg, err := pkg.NewMetaProgrammingTFConfig(&pkg.TerraformModuleRef{
+		Dir:    ".",
+		AbsDir: "/",
+	}, nil, nil, nil, context.TODO())
+	require.NoError(t, err)
+	require.NoError(t, cfg.Init(hclBlocks))
+	require.NoError(t, cfg.RunPrePlan())
+	require.NoError(t, cfg.RunPlan())
+
+	require.Len(t, fetcher.calls, 1)
+	assert.Equal(t, "/explicit/override", fetcher.calls[0].baseDir,
+		"explicit base_dir must override the auto-default")
 }

--- a/pkg/module_source.go
+++ b/pkg/module_source.go
@@ -13,12 +13,25 @@ import (
 	"github.com/hashicorp/terraform-exec/tfexec"
 )
 
-// TerraformModuleSourceFetcher fetches a remote Terraform module (registry
-// reference, git URL, etc.) and returns its parsed metadata via
-// terraform-config-inspect. Backed by `terraform get`, so only modules are
-// downloaded — no provider plugins.
+// TerraformModuleSourceFetcher fetches a Terraform module and returns its
+// parsed metadata via terraform-config-inspect.
+//
+// For local sources (./, ../, absolute paths) the fetcher resolves the source
+// against baseDir and loads it directly — no terraform invocation, no temp
+// folder. baseDir is required in this case and is normally auto-defaulted by
+// the calling data block to the target module's directory.
+//
+// For remote sources (registry shortcuts, git URLs, etc.) the fetcher writes
+// a synthetic wrapper into a temp folder and runs `terraform get` to download
+// the module. `terraform get` also validates the wrapper against the target
+// module's required inputs; that validation error is tolerated as long as the
+// download itself succeeded, because terraform-config-inspect only needs the
+// downloaded `.tf` files to parse variable and output declarations.
+//
+// baseDir is ignored for remote sources but is still expected on every call
+// so the data block layer can auto-default it uniformly.
 type TerraformModuleSourceFetcher interface {
-	Get(source, version string) (*tfconfig.Module, error)
+	Get(source, version, baseDir string) (*tfconfig.Module, error)
 }
 
 type TerraformCliModuleSourceFetcher struct {
@@ -29,7 +42,43 @@ func NewTerraformCliModuleSourceFetcher(ctx context.Context) TerraformModuleSour
 	return TerraformCliModuleSourceFetcher{ctx: ctx}
 }
 
-func (t TerraformCliModuleSourceFetcher) Get(source, version string) (*tfconfig.Module, error) {
+func (t TerraformCliModuleSourceFetcher) Get(source, version, baseDir string) (*tfconfig.Module, error) {
+	if isLocalSource(source) {
+		return loadLocalModule(source, baseDir)
+	}
+	return t.fetchRemoteModule(source, version)
+}
+
+// loadLocalModule resolves a local source (./, ../, absolute) against baseDir
+// and parses the module directly via terraform-config-inspect. No terraform
+// CLI invocation.
+func loadLocalModule(source, baseDir string) (*tfconfig.Module, error) {
+	if baseDir == "" {
+		return nil, fmt.Errorf("cannot resolve local module source %q without base_dir", source)
+	}
+	resolved := source
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(baseDir, source)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("cannot stat local module source %q (resolved to %q): %w", source, resolved, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("local module source %q (resolved to %q) is not a directory", source, resolved)
+	}
+	mod, diags := tfconfig.LoadModule(resolved)
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("error loading local module from %s: %s", resolved, diags.Error())
+	}
+	return mod, nil
+}
+
+// fetchRemoteModule downloads a remote module via `terraform get` and parses
+// it via terraform-config-inspect. Tolerates `terraform get` validation
+// errors (missing required args on the synthetic wrapper) as long as the
+// download itself succeeded.
+func (t TerraformCliModuleSourceFetcher) fetchRemoteModule(source, version string) (*tfconfig.Module, error) {
 	tmpFolder, err := os.MkdirTemp("", "mapotf-module-*")
 	if err != nil {
 		return nil, fmt.Errorf("error creating temp module folder: %s", err)
@@ -58,16 +107,65 @@ func (t TerraformCliModuleSourceFetcher) Get(source, version string) (*tfconfig.
 	if err != nil {
 		return nil, fmt.Errorf("error running NewTerraform: %w", err)
 	}
-	if err := tf.Get(t.ctx); err != nil {
-		return nil, fmt.Errorf("error running terraform get for module %q version %q: %w", source, version, err)
-	}
+	getErr := tf.Get(t.ctx)
 
 	moduleDir := filepath.Join(tmpFolder, ".terraform", "modules", "x")
-	mod, diags := tfconfig.LoadModule(moduleDir)
-	if diags.HasErrors() {
-		return nil, fmt.Errorf("error loading module from %s: %s", moduleDir, diags.Error())
+	if hasTerraformFiles(moduleDir) {
+		mod, diags := tfconfig.LoadModule(moduleDir)
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("error loading module from %s: %s", moduleDir, diags.Error())
+		}
+		// Download succeeded — any `terraform get` validation error is
+		// irrelevant because terraform-config-inspect only reads the
+		// downloaded module's variable and output declarations.
+		return mod, nil
 	}
-	return mod, nil
+
+	if getErr != nil {
+		return nil, fmt.Errorf("error running terraform get for module %q version %q: %w", source, version, getErr)
+	}
+	return nil, fmt.Errorf("terraform get completed for module %q version %q but no .tf files were downloaded to %s", source, version, moduleDir)
+}
+
+// isLocalSource reports whether source refers to a module on the local
+// filesystem (and therefore must be resolved against the caller's base_dir
+// rather than fetched via terraform get). Matches the same set of prefixes
+// Terraform itself treats as local: `./`, `../`, and absolute paths
+// (including Windows `C:\foo` and `C:/foo`).
+func isLocalSource(source string) bool {
+	if source == "" {
+		return false
+	}
+	if strings.HasPrefix(source, "./") || strings.HasPrefix(source, "../") {
+		return true
+	}
+	// Also catch `.\foo` and `..\foo` on Windows.
+	if strings.HasPrefix(source, `.\`) || strings.HasPrefix(source, `..\`) {
+		return true
+	}
+	if source == "." || source == ".." {
+		return true
+	}
+	return filepath.IsAbs(source)
+}
+
+// hasTerraformFiles reports whether dir contains at least one .tf file.
+// `.tf` files always live at module root in standard layouts so a one-level
+// scan is sufficient.
+func hasTerraformFiles(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(e.Name(), ".tf") {
+			return true
+		}
+	}
+	return false
 }
 
 func (t TerraformCliModuleSourceFetcher) getTerraformPath() (string, error) {
@@ -87,3 +185,4 @@ func (t TerraformCliModuleSourceFetcher) getTerraformPath() (string, error) {
 func (t TerraformCliModuleSourceFetcher) isWindows() bool {
 	return runtime.GOOS == "windows"
 }
+

--- a/pkg/module_source_export_test.go
+++ b/pkg/module_source_export_test.go
@@ -1,0 +1,7 @@
+package pkg
+
+// IsLocalSourceForTest is a test-only re-export of the package-private
+// isLocalSource helper so external _test packages can exercise it.
+func IsLocalSourceForTest(source string) bool {
+	return isLocalSource(source)
+}

--- a/pkg/module_source_test.go
+++ b/pkg/module_source_test.go
@@ -1,0 +1,125 @@
+package pkg_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/Azure/mapotf/pkg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsLocalSource(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"empty", "", false},
+		{"current_dir", "./", true},
+		{"current_dir_no_slash", ".", true},
+		{"parent_dir", "../", true},
+		{"parent_dir_no_slash", "..", true},
+		{"current_dir_subpath", "./submod", true},
+		{"parent_dir_subpath", "../../shared/foo", true},
+		{"windows_current_dir", `.\submod`, true},
+		{"windows_parent_dir", `..\..\shared`, true},
+		{"unix_absolute", "/foo/bar/mod", runtime.GOOS != "windows"},
+		{"windows_absolute_backslash", `C:\foo\mod`, runtime.GOOS == "windows"},
+		{"windows_absolute_forward", `C:/foo/mod`, runtime.GOOS == "windows"},
+		{"registry_short", "Azure/naming/azurerm", false},
+		{"registry_with_subdir", "Azure/naming/azurerm//modules/dns", false},
+		{"git_https", "git::https://github.com/Azure/foo.git", false},
+		{"git_ssh", "git@github.com:Azure/foo.git", false},
+		{"bare_word", "naming", false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := pkg.IsLocalSourceForTest(tc.in)
+			assert.Equal(t, tc.want, got, "source = %q", tc.in)
+		})
+	}
+}
+
+// TestTerraformCliModuleSourceFetcher_LocalSource pins the U2 fix: local
+// sources are resolved against base_dir via terraform-config-inspect alone,
+// with no terraform CLI invocation. Therefore this test can run even when
+// terraform is absent from PATH.
+func TestTerraformCliModuleSourceFetcher_LocalSource(t *testing.T) {
+	t.Parallel()
+	baseDir := t.TempDir()
+	submod := filepath.Join(baseDir, "submod")
+	require.NoError(t, os.Mkdir(submod, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(submod, "variables.tf"), []byte(`
+variable "name" {
+  type = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(submod, "outputs.tf"), []byte(`
+output "id" {
+  value = "x"
+}
+`), 0o600))
+
+	sut := pkg.NewTerraformCliModuleSourceFetcher(context.Background())
+	mod, err := sut.Get("./submod", "", baseDir)
+	require.NoError(t, err)
+	require.NotNil(t, mod)
+
+	require.Contains(t, mod.Variables, "name")
+	require.Contains(t, mod.Variables, "tags")
+	assert.True(t, mod.Variables["name"].Required, "name has no default → must be Required")
+	assert.False(t, mod.Variables["tags"].Required, "tags has a default → must not be Required")
+
+	require.Contains(t, mod.Outputs, "id")
+}
+
+func TestTerraformCliModuleSourceFetcher_LocalSourceMissingBaseDir(t *testing.T) {
+	t.Parallel()
+	sut := pkg.NewTerraformCliModuleSourceFetcher(context.Background())
+	_, err := sut.Get("./submod", "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "base_dir", "error must explain that base_dir is required for local sources")
+}
+
+func TestTerraformCliModuleSourceFetcher_LocalSourceMissingDirectory(t *testing.T) {
+	t.Parallel()
+	baseDir := t.TempDir()
+	sut := pkg.NewTerraformCliModuleSourceFetcher(context.Background())
+	_, err := sut.Get("./does-not-exist", "", baseDir)
+	require.Error(t, err)
+}
+
+// TestTerraformCliModuleSourceFetcher_RemoteSourceToleratesValidationError
+// pins the U3 fix: when `terraform get` succeeds in downloading the module
+// but fails wrapper-validation (because the synthetic wrapper passes zero
+// inputs and the target module declares required inputs), the fetcher should
+// still parse the downloaded module via terraform-config-inspect. This test
+// requires terraform on PATH because it exercises the real CLI path.
+func TestTerraformCliModuleSourceFetcher_RemoteSourceToleratesValidationError(t *testing.T) {
+	if _, err := exec.LookPath("terraform"); err != nil {
+		t.Skip("Skipping test because Terraform is not available on PATH")
+	}
+	// Azure/naming/azurerm v0.4.0 declares no required inputs (every variable
+	// has a default), so it's the safest registry module to exercise the
+	// remote-fetch happy path without paying the cost of a flaky network
+	// dependency on a module with required args.
+	sut := pkg.NewTerraformCliModuleSourceFetcher(context.Background())
+	mod, err := sut.Get("Azure/naming/azurerm", "0.4.0", "")
+	require.NoError(t, err)
+	require.NotNil(t, mod)
+	// Sanity: the naming module has known variables.
+	assert.NotEmpty(t, mod.Variables)
+}

--- a/pkg/mptf_config.go
+++ b/pkg/mptf_config.go
@@ -118,6 +118,18 @@ func (c *MetaProgrammingTFConfig) TerraformBlock() *terraform.RootBlock {
 	return c.terraformBlock
 }
 
+// ModuleDir returns the absolute directory of the Terraform module mapotf is
+// currently transforming. Used by data blocks that need to resolve paths
+// declared in the caller's `.mptf.hcl` (for example `data "module_source"`
+// auto-defaults its `base_dir` to this so relative sources resolve against
+// the caller's module, not against an internal temp folder).
+func (c *MetaProgrammingTFConfig) ModuleDir() string {
+	if c.module == nil {
+		return ""
+	}
+	return c.module.AbsDir
+}
+
 func (c *MetaProgrammingTFConfig) RootBlock(address string) *terraform.RootBlock {
 	if strings.HasPrefix(address, "resource.") {
 		return c.resourceBlocks[address]


### PR DESCRIPTION
# Summary

Fixes two latent bugs in `data "module_source"` (v0.1.3) that prevented it working against any real AVM module.

Closes #104. Closes #105.

## U2 — relative source paths resolve against the wrong directory (#104)

**Before:** `data "module_source" { source = "./submod" }` errored with `Unable to evaluate directory symlink: GetFileAttributesEx submod: The system cannot find the file specified.`

**Cause:** `TerraformCliModuleSourceFetcher.Get` created a fresh tempdir, wrote a synthetic `module "x" { source = "./submod" }` into it, and ran `terraform get` from that tempdir. Relative sources resolved against the tempdir, never against the calling module's directory.

**Fix:** New optional `base_dir` HCL field on `data "module_source"` (auto-defaults to the target module's `AbsDir`). When the source is local (`./`, `../`, or an absolute path) the fetcher short-circuits the synthetic-wrapper dance entirely and calls `tfconfig.LoadModule(filepath.Join(baseDir, source))` directly.

## U3 — `terraform get` rejects synthetic wrapper against target module required args (#105)

**Before:** Even after working around U2, the fetcher errored with `The argument "name" is required, but no definition was found.  The argument "location" is required, but no definition was found.` against any module with required inputs (every real AVM module has `location`).

**Cause:** `terraform get` runs the same module-config validation `terraform init` does. The synthetic `module "x" { source = "..." }` mapotf generates passes zero inputs, so any target with required args fails validation. The download itself succeeds before validation; we just abandoned the result.

**Fix:** For remote sources, run `tf.Get(ctx)` as before, but tolerate the validation error: if `.terraform/modules/x` exists and contains `.tf` files, the download succeeded — call `tfconfig.LoadModule(.terraform/modules/x)` regardless. `tfconfig` only reads variable + output declarations; it doesn't care about wrapper validity.

# Worked example

After this PR (no config changes needed — `base_dir` auto-defaults):

```hcl
data "module" "all" {}

data "module_source" "per_module" {
  for_each = data.module.all.result
  source   = each.value.source
  version  = try(each.value.version, "")
}

transform "reorder_attributes" "module_inputs" {
  for_each             = data.module_source.per_module
  target_block_address = "module.${each.key}"
  head_attributes      = ["source", "version", "for_each", "count", "providers"]
  body_attributes      = concat(each.value.required_variables, each.value.optional_variables)
  foot_attributes      = ["depends_on"]
}
```

This unblocks the AVM governance G4 use case (module input required-vs-optional ordering) against both local and registry sources.

# Changes

| File | Action |
|---|---|
| `pkg/module_source.go` | Interface gains `baseDir string`; new `isLocalSource` / `hasTerraformFiles` helpers; local-source short-circuit; remote-source ignore-validation flow |
| `pkg/data_module_source.go` | New `BaseDir string` HCL field with `hcl:"base_dir,optional"`; auto-defaults from `MetaProgrammingTFConfig.ModuleDir()` |
| `pkg/mptf_config.go` | New `ModuleDir() string` accessor returning `c.module.AbsDir` |
| `pkg/module_source_test.go` (new) | Table tests for `isLocalSource`; fetcher local-source path; remote-source validation tolerance |
| `pkg/module_source_export_test.go` (new) | Internal test seam to expose `isLocalSource` |
| `pkg/data_module_source_test.go` | New tests pinning auto-default behaviour + explicit override |
| `doc/d/module_source.md` | Document `base_dir` argument with auto-default rule; rewrite "Under the Hood" for dual local/remote paths and validation tolerance |

# Verification

- `go test ./... -count=1` — all packages green (cmd, pkg, pkg/backup, pkg/terraform)
- `golangci-lint v2.4.0-alpine --timeout=5m ./...` — 0 issues

The governance session has a preserved fixture at `$env:TEMP\g4-verify\` (module `scrambled` calling `./submod`) and will re-verify against this PR's branch SHA before the v0.1.4 tag fires.
