### PR TITLE
Consolidate CodeQL scanning for Go and Actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,52 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '19 13 * * 4'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: go
+            build-mode: manual
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
+
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e #v4.36.2
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          tools: linked
+
+      - name: Build Go
+        if: matrix.language == 'go'
+        shell: pwsh
+        run: go build ./...
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e #v4.36.2
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -9,6 +9,9 @@ on:
 env:
   TOKEN: ${{secrets.GITHUB_TOKEN}}
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Build and Test
@@ -16,9 +19,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-    permissions:
-      # required for all workflows
-      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
@@ -27,15 +27,9 @@ jobs:
         with:
           go-version-file: go.mod
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e #v4.0.1
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e #v4.36.2
-        with:
-          languages: go
       - name: Run build
         run: |
           go build github.com/Azure/mapotf
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e #v4.36.2
       - name: Run tests
 
         run: go test -v github.com/Azure/mapotf/...


### PR DESCRIPTION
## Summary

- move CodeQL out of the Ubuntu/Windows build matrix into one dedicated Linux workflow
- scan Go and GitHub Actions on pushes, pull requests, and a weekly schedule
- pin Actions by SHA and use the Action-linked CodeQL bundle so database format changes follow reviewed Action updates
- reduce the build workflow token to `contents: read`

## Why

S360 reports that `github:azure/mapotf` needs a Go snapshot. GitHub CodeQL itself is configured and passing, but CAP Central job [`5d1a40d6-9006-473e-9e77-14ae2cabd570`](https://codeql.microsoft.com/job/5d1a40d6-9006-473e-9e77-14ae2cabd570) failed because its CodeQL 2.26.0 analyzer and Microsoft Go query pack 0.1.565 could not analyze a newer GitHub-generated database. The dedicated workflow uses the bundle linked to the reviewed Action version while removing duplicate per-OS scans.

GitHub default setup is also active today. After this pull request merges, a repository administrator should disable default setup so this advanced workflow is the only CodeQL producer.

## Validation

- `go build ./...`
- `go test ./...`