### PR TITLE
fix(release): use cosign v3 bundle format for keyless signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 #v4.1.2
+        with:
+          cosign-release: 'v3.0.6'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 #v7.2.2
@@ -39,3 +41,11 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify checksum signature
+        run: |
+          cosign verify-blob \
+            --bundle dist/checksums.txt.sigstore.json \
+            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/release.yml@${{ github.ref }}" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            dist/checksums.txt

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,11 +46,10 @@ checksum:
 
 signs:
   - cmd: cosign
-    certificate: '${artifact}.pem'
+    signature: '${artifact}.sigstore.json'
     args:
       - sign-blob
-      - '--output-certificate=${certificate}'
-      - '--output-signature=${signature}'
+      - '--bundle=${signature}'
       - '${artifact}'
       - '--yes'
     artifacts: checksum


### PR DESCRIPTION
## Problem

The `v0.1.5` release run [failed at the signing step](https://github.com/Azure/mapotf/actions/runs/30926142143/job/92048857482):

```
Error: signing dist/checksums.txt: create bundle file: open : no such file or directory
⨯ release failed after 2m53s  error=exit status 1  message=could not sign artifact  cmd=cosign
```

The tag and GitHub release for `v0.1.5` exist but have **zero assets** — nothing was published.

## Root cause

`sigstore/cosign-installer@v4.1.2` defaults to **cosign `v3.0.6`**, and cosign v3 makes `--new-bundle-format` the default. That deprecates `--output-signature` and `--output-certificate`:

```
WARNING: --output-signature is deprecated when using --new-bundle-format and will be ignored
WARNING: --output-certificate is deprecated when using --new-bundle-format and will be ignored
```

cosign then writes to the `--bundle` path instead — which we never passed, so it resolved to an empty string and the open failed. The `signs` block was written against cosign v2 semantics and the unpinned installer silently rolled onto v3.

## Fix

- Emit a single Sigstore bundle, `checksums.txt.sigstore.json`, via `--bundle=${signature}`. This is the same idiom GoReleaser uses for its own releases. The bundle carries both the signature and the certificate, so the separate `.pem` is no longer needed.
- Pin `cosign-release: 'v3.0.6'` so the signing toolchain cannot drift underneath us again. This is the actual preventative — the config was schema-valid, so `goreleaser check` would not have caught the regression.
- Add a post-release `cosign verify-blob` step so an unusable signature fails the job rather than shipping quietly.

## Validation

Ran a full `goreleaser release --snapshot --skip=publish,validate` locally against a stub `cosign` that emulates v3 (fails unless given a non-empty `--bundle`):

```
• signing artifacts
  • signing   cmd=cosign artifact=checksums.txt signature=dist/checksums.txt.sigstore.json
• release succeeded after 34s

ARGS: sign-blob --bundle=dist/checksums.txt.sigstore.json dist/checksums.txt --yes
WROTE: dist/checksums.txt.sigstore.json
```

`goreleaser check` passes and both YAML files parse.

## Verifying a release

```bash
cosign verify-blob \
  --bundle checksums.txt.sigstore.json \
  --certificate-identity "https://github.com/Azure/mapotf/.github/workflows/release.yml@refs/tags/v0.1.5" \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  checksums.txt
```

## Follow-up needed after merge

`v0.1.5` is tagged at `ef2bb3e`, which does **not** contain this fix, so re-running the failed workflow will just fail again. Since the release published no assets, either the tag needs moving to the merge commit or a `v0.1.6` needs cutting. Happy to do whichever you prefer.

> [!NOTE]
> This is unrelated to the Defender false positive — cosign signatures are detached and cannot change the Windows verdict. Authenticode via ESRP remains the fix for that, tracked separately.