### PR TITLE
Trigger checksum signing on the pre-release to release transition

### DIFF
--- a/.github/workflows/sign-checksums.yml
+++ b/.github/workflows/sign-checksums.yml
@@ -2,7 +2,7 @@ name: sign-checksums
 
 on:
   release:
-    types: [published]
+    types: [released]
   workflow_dispatch:
     inputs:
       tag:
@@ -26,15 +26,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ inputs.tag || github.event.release.tag_name }}
         run: |
-          # The release pipeline attaches the assets while the release is still a draft, so they are
-          # already present when this runs; the retry only absorbs GitHub API lag. A release published
-          # by any other route has nothing to sign, so the job stops quietly rather than failing.
-          $found = $false
-          foreach ($attempt in 1..6) {
-            $assets = gh release view $env:TAG --repo $env:GITHUB_REPOSITORY --json assets --jq '.assets[].name' 2>$null
-            if (@($assets) -contains 'checksums.txt') { $found = $true; break }
-            Start-Sleep -Seconds 10
-          }
+          # The release pipeline uploads the assets before it promotes the pre-release, so a
+          # successful pipeline run always leaves checksums.txt attached by the time this fires.
+          # Anything else - a release promoted by hand, or a failed pipeline run - has nothing to
+          # sign, so the job stops quietly rather than failing or waiting for a file that is not
+          # coming.
+          $assets = gh release view $env:TAG --repo $env:GITHUB_REPOSITORY --json assets --jq '.assets[].name' 2>$null
+          $found = @($assets) -contains 'checksums.txt'
           "found=$($found.ToString().ToLower())" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           if (-not $found) {
             Write-Host "::warning::No checksums.txt attached to release $env:TAG, nothing to sign."


### PR DESCRIPTION
## What changed

`sign-checksums.yml` now triggers on `release: released` instead of `release: published`, and the polling loop is replaced with a single fail-fast check.

## Why

The design this workflow was written against could never have worked. The ADO release pipeline checks the release tag out:

```powershell
git -C "$(mapotfRoot)" checkout --quiet --detach "refs/tags/$tag"
```

A **draft GitHub release stores `tag_name` but creates no git ref** — the tag only comes into existence when the release is published. So the "author a draft, let the pipeline publish it" flow would have killed the pipeline at step 2, before building anything.

The release is now authored as a **published pre-release**, which creates the tag immediately. The pipeline uploads the assets and then promotes the pre-release to a full release in a second edit.

GitHub defines the `released` activity type as *"A release was published, **or a pre-release was changed to a release**."* That promotion is the only event that fires after every asset is attached, so it is the correct trigger.

`published` is wrong here — it fires when the human first publishes the pre-release, before the pipeline has run at all.

## Why the polling loop goes

`GitHubRelease@1` uploads the assets in the step *before* the one that promotes the release, so `checksums.txt` is always attached by the time this workflow fires. There is nothing to wait for.

If `checksums.txt` is absent, the release was promoted by some route other than a successful pipeline run, and no amount of waiting will produce it. The workflow now emits a warning and stops immediately rather than spending a minute discovering that.

## Release procedure after this change

1. Create the release on `Azure/mapotf` by hand — tag, notes, **publish it as a pre-release**.
2. Queue ADO definition 1203 with `version = vX.Y.Z`.
3. The pipeline builds six targets, ESRP-signs the Windows binaries, packages the archives and `checksums.txt`, uploads them, then promotes the release.
4. Promotion fires `released`, this workflow signs `checksums.txt` with keyless cosign and attaches `checksums.txt.sigstore.json`.

## Companion change

ADO PR 2278 in `github-private/azure/Azure-Verified-Modules` carries the pipeline side: the two-step pre-release flip, and `releaseAction`/`preRelease` collapsed into a single `dryRun` boolean.
