### PR TITLE
fix(terraform): handle heterogeneous nested block types

### DIFF
--- a/pkg/terraform/nested_block_test.go
+++ b/pkg/terraform/nested_block_test.go
@@ -214,6 +214,100 @@ resource "fake_resource" this {
 	assert.Equal(t, `John`, value.AsString())
 }
 
+func TestNestedBlock_SameAttributeHasVariableLengthTuple(t *testing.T) {
+	code := `
+resource "fake_resource" "this" {
+  rule {
+    destination_fqdns = ["one.example.com"]
+  }
+  rule {
+    destination_fqdns = ["one.example.com", "two.example.com"]
+  }
+  rule {
+    destination_fqdns = ["one.example.com", "two.example.com", "three.example.com"]
+  }
+}
+`
+
+	rules := newBlock(t, code).EvalContext().GetAttr("rule")
+	require.True(t, rules.Type().IsListType())
+	require.True(t, rules.Type().ElementType().IsObjectType())
+	require.True(t, cty.List(cty.String).Equals(rules.Type().ElementType().AttributeTypes()["destination_fqdns"]))
+
+	expected := []cty.Value{
+		cty.ListVal([]cty.Value{cty.StringVal("one.example.com")}),
+		cty.ListVal([]cty.Value{
+			cty.StringVal("one.example.com"),
+			cty.StringVal("two.example.com"),
+		}),
+		cty.ListVal([]cty.Value{
+			cty.StringVal("one.example.com"),
+			cty.StringVal("two.example.com"),
+			cty.StringVal("three.example.com"),
+		}),
+	}
+	for i, value := range expected {
+		actual := rules.Index(cty.NumberIntVal(int64(i))).GetAttr("destination_fqdns")
+		assert.True(t, value.RawEquals(actual), "unexpected rule %d value: %s", i, actual.GoString())
+	}
+}
+
+func TestNestedBlock_SameAttributeHasLiteralAndExpressionValues(t *testing.T) {
+	code := `
+resource "fake_resource" "this" {
+  dynamic "identity" {
+    for_each = local.system_assigned_only
+    content {
+      type         = identity.value.type
+      identity_ids = []
+    }
+  }
+  dynamic "identity" {
+    for_each = local.includes_user_assigned
+    content {
+      type         = identity.value.type
+      identity_ids = identity.value.user_assigned_resource_ids
+    }
+  }
+}
+`
+
+	identities := newBlock(t, code).EvalContext().GetAttr("identity")
+	require.True(t, identities.Type().IsTupleType())
+
+	firstIDs := identities.Index(cty.NumberIntVal(0)).GetAttr("identity_ids")
+	assert.True(t, cty.EmptyTupleVal.RawEquals(firstIDs), "unexpected literal value: %s", firstIDs.GoString())
+
+	secondIDs := identities.Index(cty.NumberIntVal(1)).GetAttr("identity_ids")
+	assert.Equal(t, "identity.value.user_assigned_resource_ids", secondIDs.AsString())
+}
+
+func TestNestedBlock_NestedAttributeHasLiteralAndExpressionValues(t *testing.T) {
+	code := `
+resource "fake_resource" "this" {
+  top_block {
+    child_block {
+      values = []
+    }
+  }
+  top_block {
+    child_block {
+      values = item.value.ids
+    }
+  }
+}
+`
+
+	topBlocks := newBlock(t, code).EvalContext().GetAttr("top_block")
+	require.True(t, topBlocks.Type().IsTupleType())
+
+	firstValue := topBlocks.Index(cty.NumberIntVal(0)).GetAttr("child_block").Index(cty.NumberIntVal(0)).GetAttr("values")
+	assert.True(t, cty.EmptyTupleVal.RawEquals(firstValue), "unexpected literal value: %s", firstValue.GoString())
+
+	secondValue := topBlocks.Index(cty.NumberIntVal(1)).GetAttr("child_block").Index(cty.NumberIntVal(0)).GetAttr("values")
+	assert.Equal(t, "item.value.ids", secondValue.AsString())
+}
+
 func TestNestedBlock_RemoveNestedBlock(t *testing.T) {
 	cfg := `
 root_block {

--- a/pkg/terraform/object.go
+++ b/pkg/terraform/object.go
@@ -16,9 +16,13 @@ type Object interface {
 func ListOfObject[T Object](objs []T) cty.Value {
 	var values []cty.Value
 	allTypes := make(map[string]cty.Type)
+	canBuildList := true
 	for _, b := range objs {
 		value := b.EvalContext()
 		values = append(values, value)
+		if !canBuildList {
+			continue
+		}
 		attributeTypes := value.Type().AttributeTypes()
 		for n, t := range attributeTypes {
 			if _, ok := allTypes[n]; !ok {
@@ -27,12 +31,25 @@ func ListOfObject[T Object](objs []T) cty.Value {
 			}
 			if !allTypes[n].Equals(t) {
 				if allTypes[n].IsListType() && t.IsListType() {
-					allTypes[n] = cty.List(mergeObjectType(allTypes[n].ElementType(), t.ElementType()))
+					elementType := mergeObjectType(allTypes[n].ElementType(), t.ElementType())
+					if elementType == cty.NilType {
+						canBuildList = false
+						break
+					}
+					allTypes[n] = cty.List(elementType)
 					continue
 				}
-				allTypes[n] = mergeObjectType(allTypes[n], t)
+				mergedType := mergeObjectType(allTypes[n], t)
+				if mergedType == cty.NilType {
+					canBuildList = false
+					break
+				}
+				allTypes[n] = mergedType
 			}
 		}
+	}
+	if !canBuildList {
+		return cty.TupleVal(values)
 	}
 	var allFields []string
 	linq.From(allTypes).Select(func(i interface{}) interface{} {
@@ -54,11 +71,18 @@ func ListOfObject[T Object](objs []T) cty.Value {
 }
 
 func mergeObjectType(t1, t2 cty.Type) cty.Type {
+	if t1.IsTupleType() || t2.IsTupleType() {
+		unifiedType, _ := convert.Unify([]cty.Type{t1, t2})
+		return unifiedType
+	}
 	if t1.IsPrimitiveType() && t2.IsPrimitiveType() {
 		return t1
 	}
 	if t1.IsCollectionType() && t2.IsCollectionType() {
 		return mergeObjectTypeInCollection(t1, t2)
+	}
+	if !t1.IsObjectType() || !t2.IsObjectType() {
+		return cty.NilType
 	}
 	newAttriubtes := make(map[string]cty.Type)
 	for n, t := range t1.AttributeTypes() {
@@ -69,7 +93,11 @@ func mergeObjectType(t1, t2 cty.Type) cty.Type {
 			newAttriubtes[n] = t
 			continue
 		}
-		newAttriubtes[n] = mergeObjectType(newAttriubtes[n], t)
+		mergedType := mergeObjectType(newAttriubtes[n], t)
+		if mergedType == cty.NilType {
+			return cty.NilType
+		}
+		newAttriubtes[n] = mergedType
 	}
 	var allFields []string
 	for n := range newAttriubtes {
@@ -81,6 +109,9 @@ func mergeObjectType(t1, t2 cty.Type) cty.Type {
 func mergeObjectTypeInCollection(t1, t2 cty.Type) cty.Type {
 	if t1.ElementType().IsObjectType() && t2.ElementType().IsObjectType() {
 		mergedElementType := mergeObjectType(t1.ElementType(), t2.ElementType())
+		if mergedElementType == cty.NilType {
+			return cty.NilType
+		}
 		if t1.IsListType() {
 			return cty.List(mergedElementType)
 		}


### PR DESCRIPTION
## Summary
- unify compatible tuple types before object-type merging
- preserve heterogeneous repeated blocks as tuples when no homogeneous list type exists
- add regressions for variable-length tuples, mixed literal/expression values, and nested propagation

## Why
`mapotf 0.1.7` can call `AttributeTypes()` on tuple values while building evaluation contexts for repeated nested blocks, causing `panic: AttributeTypes on non-object Type`.

Observed in:
- https://github.com/Azure/avm-terraform-governance/actions/runs/31372546045/job/93404597406
- https://github.com/Azure/avm-terraform-governance/actions/runs/31372546045/job/93404608762

## Validation
- `go build github.com/Azure/mapotf`
- `go test ./...`
- `golangci-lint run --timeout=3600s`
- completed the production AVM transform bundle against both affected repositories