### PR TITLE
feat(transform): reorder nested block attributes

### DIFF
--- a/doc/t/reorder_attributes.md
+++ b/doc/t/reorder_attributes.md
@@ -22,6 +22,7 @@ This transform composes with `data` blocks like `data "resource"`, `data "variab
 - `foot_attributes` *(optional)*: Names of elements that should appear last, in the listed order.
 - `head_foot_line_breaks` *(optional, default `true`)*: When `true`, a blank line is inserted between the head section and the body, and between the body and the foot section. Set to `false` to suppress those blank lines.
 - `sort_body_alphabetically` *(optional, default `true`)*: Controls the order of body-section elements that are **not** listed in `body_attributes`. When `true`, those elements are sorted alphabetically by name. Set to `false` to preserve the original source order instead.
+- `nested_block_path` *(optional)*: A non-empty list of nested block names below `target_block_address`. When set, the transform resolves exactly one block at every path segment and alphabetizes only the direct attributes in the selected block. This focused mode cannot be combined with the section-ordering arguments above, and the selected block cannot itself contain nested blocks.
 
 ### How `body_attributes` and `sort_body_alphabetically` interact
 
@@ -80,6 +81,38 @@ variable "location" {
 ```
 
 The blank line between the head (`type`, `description`) and the body (`default`) comes from the default `head_foot_line_breaks = true`.
+
+## Example - Sort `required_providers` entries
+
+Use `nested_block_path` to order provider entries without rewriting their values:
+
+```terraform
+transform "reorder_attributes" "required_providers" {
+  target_block_address = "terraform"
+  nested_block_path    = ["required_providers"]
+}
+```
+
+Given:
+
+```terraform
+terraform {
+  required_providers {
+    random = {
+      source = "hashicorp/random"
+    }
+
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}
+```
+
+After applying the transform, `azurerm` precedes `random`. The `source` and `version` keys inside each provider object are left exactly as written, along with the provider expression and its comments.
+
+If a path segment is missing or has more than one matching nested block, the transform fails rather than choosing one. Multi-level paths are supported, for example `nested_block_path = ["first", "second"]`.
 
 ## Example - Head and foot together
 
@@ -157,4 +190,3 @@ The body section emits provider-required attributes first (alphabetical within t
 - The transform runs against the parsed HCL writer view of the block, so comments and formatting on individual attributes are preserved.
 - Nested blocks have a blank line in front of them when they are preceded by an attribute or a nested block of a different type; adjacent nested blocks of the same type (and, for `dynamic`, the same label) stay adjacent without a separating blank line. A section-boundary blank line counts — no extra blank line is added when one is already being emitted.
 - Nested blocks of the same type that appear multiple times (e.g. two `network_interface` blocks) keep their write-side order when grouped together by name.
-

--- a/pkg/transform_reorder_attributes.go
+++ b/pkg/transform_reorder_attributes.go
@@ -54,6 +54,7 @@ type ReorderAttributesTransform struct {
 	FootAttributes         []string `hcl:"foot_attributes,optional"`
 	HeadFootLineBreaks     *bool    `hcl:"head_foot_line_breaks,optional"`
 	SortBodyAlphabetically *bool    `hcl:"sort_body_alphabetically,optional"`
+	NestedBlockPath        []string `hcl:"nested_block_path,optional"`
 }
 
 func (r *ReorderAttributesTransform) Type() string {
@@ -69,6 +70,10 @@ func (r *ReorderAttributesTransform) Apply() error {
 
 	if err := validateReorderSectionOverlap(r.HeadAttributes, r.BodyAttributes, r.FootAttributes); err != nil {
 		return err
+	}
+
+	if r.NestedBlockPath != nil {
+		return r.reorderNestedBlockAttributes(block)
 	}
 
 	body := block.WriteBlock.Body()
@@ -93,6 +98,81 @@ func (r *ReorderAttributesTransform) Apply() error {
 	body.AppendNewline()
 	emitReorderElements(body, final, len(headElems), len(headElems)+len(bodyElems), r.useHeadFootLineBreaks())
 	return nil
+}
+
+// reorderNestedBlockAttributes alphabetizes direct attributes of one uniquely
+// addressed nested block. It deliberately does not reorder nested blocks or
+// provider object expressions, so the operation remains a layout-only change.
+func (r *ReorderAttributesTransform) reorderNestedBlockAttributes(block *terraform.RootBlock) error {
+	if err := r.validateNestedBlockPathConfig(); err != nil {
+		return err
+	}
+
+	target, err := findUniqueNestedBlock(block, r.NestedBlockPath)
+	if err != nil {
+		return err
+	}
+
+	body := target.WriteBody()
+	if len(body.Blocks()) > 0 {
+		return fmt.Errorf("reorder_attributes: nested block path %q contains nested blocks and cannot be safely reordered", formatNestedBlockPath(r.NestedBlockPath))
+	}
+
+	attrs := body.Attributes()
+	if len(attrs) < 2 {
+		return nil
+	}
+
+	names := make([]string, 0, len(attrs))
+	for name := range attrs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	body.Clear()
+	body.AppendNewline()
+	for _, name := range names {
+		body.AppendUnstructuredTokens(attrs[name].BuildTokens(nil))
+	}
+	return nil
+}
+
+func (r *ReorderAttributesTransform) validateNestedBlockPathConfig() error {
+	if len(r.NestedBlockPath) == 0 {
+		return fmt.Errorf("reorder_attributes: nested_block_path must contain at least one block name")
+	}
+	for _, name := range r.NestedBlockPath {
+		if name == "" {
+			return fmt.Errorf("reorder_attributes: nested_block_path must not contain empty block names")
+		}
+	}
+	if len(r.HeadAttributes) > 0 || len(r.BodyAttributes) > 0 || len(r.FootAttributes) > 0 || r.HeadFootLineBreaks != nil || r.SortBodyAlphabetically != nil {
+		return fmt.Errorf("reorder_attributes: nested_block_path cannot be combined with head_attributes, body_attributes, foot_attributes, head_foot_line_breaks, or sort_body_alphabetically")
+	}
+	return nil
+}
+
+func findUniqueNestedBlock(block *terraform.RootBlock, path []string) (*terraform.NestedBlock, error) {
+	var current *terraform.NestedBlock
+	nestedBlocks := block.GetNestedBlocks()
+	for index, name := range path {
+		matches := nestedBlocks[name]
+		if len(matches) == 0 {
+			return nil, fmt.Errorf("reorder_attributes: cannot find nested block path %q: segment %q does not exist", formatNestedBlockPath(path), name)
+		}
+		if len(matches) > 1 {
+			return nil, fmt.Errorf("reorder_attributes: nested block path %q is ambiguous at segment %q: found %d matching blocks", formatNestedBlockPath(path), name, len(matches))
+		}
+		current = matches[0]
+		if index < len(path)-1 {
+			nestedBlocks = current.GetNestedBlocks()
+		}
+	}
+	return current, nil
+}
+
+func formatNestedBlockPath(path []string) string {
+	return strings.Join(path, ".")
 }
 
 func (r *ReorderAttributesTransform) useHeadFootLineBreaks() bool {

--- a/pkg/transform_reorder_attributes_test.go
+++ b/pkg/transform_reorder_attributes_test.go
@@ -864,6 +864,135 @@ variable "example" {
 			wantErr:        true,
 			errorSubstring: "cannot be in both body_attributes and foot_attributes",
 		},
+		{
+			desc: "nested_required_providers_sorts_entries_and_preserves_comments_and_expressions",
+			mptf: `
+transform "reorder_attributes" this {
+  target_block_address = "terraform"
+  nested_block_path    = ["required_providers"]
+}
+`,
+			tfConfig: `
+terraform {
+  required_providers {
+    # The random provider is used for unique names.
+    random = {
+      version = var.random_version
+      source  = "hashicorp/random"
+    }
+
+    azurerm = {
+      version = "~> 4.0"
+      source  = "hashicorp/azurerm"
+    }
+  }
+}
+`,
+			expected: `
+terraform {
+  required_providers {
+    azurerm = {
+      version = "~> 4.0"
+      source  = "hashicorp/azurerm"
+    }
+    # The random provider is used for unique names.
+    random = {
+      version = var.random_version
+      source  = "hashicorp/random"
+    }
+  }
+}
+`,
+		},
+		{
+			desc: "nested_block_path_supports_multiple_levels",
+			mptf: `
+transform "reorder_attributes" this {
+  target_block_address = "resource.fake_resource.this"
+  nested_block_path    = ["first", "second"]
+}
+`,
+			tfConfig: `
+resource "fake_resource" this {
+  first {
+    second {
+      zeta  = 3
+      alpha = 1
+      mid   = 2
+    }
+  }
+}
+`,
+			expected: `
+resource "fake_resource" this {
+  first {
+    second {
+      alpha = 1
+      mid   = 2
+      zeta  = 3
+    }
+  }
+}
+`,
+		},
+		{
+			desc: "missing_nested_block_path_returns_error",
+			mptf: `
+transform "reorder_attributes" this {
+  target_block_address = "terraform"
+  nested_block_path    = ["required_providers"]
+}
+`,
+			tfConfig: `
+terraform {
+  required_version = ">= 1.9"
+}
+`,
+			wantErr:        true,
+			errorSubstring: `cannot find nested block path "required_providers"`,
+		},
+		{
+			desc: "duplicate_nested_block_path_returns_ambiguity_error",
+			mptf: `
+transform "reorder_attributes" this {
+  target_block_address = "terraform"
+  nested_block_path    = ["required_providers"]
+}
+`,
+			tfConfig: `
+terraform {
+  required_providers {
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+  }
+}
+`,
+			wantErr:        true,
+			errorSubstring: `nested block path "required_providers" is ambiguous`,
+		},
+		{
+			desc: "empty_nested_block_path_returns_error",
+			mptf: `
+transform "reorder_attributes" this {
+  target_block_address = "terraform"
+  nested_block_path    = []
+}
+`,
+			tfConfig: `
+terraform {
+  required_providers {}
+}
+`,
+			wantErr:        true,
+			errorSubstring: "nested_block_path must contain at least one block name",
+		},
 	}
 
 	for _, c := range cases {
@@ -901,6 +1030,86 @@ variable "example" {
 			assert.Equal(t, expected, actual)
 		})
 	}
+}
+
+func TestReorderAttributes_NestedBlockPathIsIdempotent(t *testing.T) {
+	stub := gostub.Stub(&filesystem.Fs, fakeFs(map[string]string{
+		"/main.tf": `
+terraform {
+  required_providers {
+    random = {
+      source = "hashicorp/random"
+    }
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+  }
+}
+`,
+	}))
+	defer stub.Reset()
+
+	mptf := `
+transform "reorder_attributes" this {
+  target_block_address = "terraform"
+  nested_block_path    = ["required_providers"]
+}
+`
+	readFile, diag := hclsyntax.ParseConfig([]byte(mptf), "test.hcl", hcl.InitialPos)
+	require.Falsef(t, diag.HasErrors(), diag.Error())
+	writeFile, diag := hclwrite.ParseConfig([]byte(mptf), "test.hcl", hcl.InitialPos)
+	require.Falsef(t, diag.HasErrors(), diag.Error())
+	hclBlock := golden.NewHclBlock(readFile.Body.(*hclsyntax.Body).Blocks[0], writeFile.Body().Blocks()[0], nil)
+	cfg, err := pkg.NewMetaProgrammingTFConfig(&pkg.TerraformModuleRef{
+		Dir:    "/",
+		AbsDir: "/",
+	}, nil, []*golden.HclBlock{hclBlock}, nil, context.TODO())
+	require.NoError(t, err)
+	plan, err := pkg.RunMetaProgrammingTFPlan(cfg)
+	require.NoError(t, err)
+
+	require.NoError(t, plan.Apply())
+	afterFirstApply, err := afero.ReadFile(filesystem.Fs, "/main.tf")
+	require.NoError(t, err)
+
+	require.NoError(t, plan.Apply())
+	afterSecondApply, err := afero.ReadFile(filesystem.Fs, "/main.tf")
+	require.NoError(t, err)
+
+	assert.Equal(t, formatHcl(string(afterFirstApply)), formatHcl(string(afterSecondApply)))
+}
+
+func TestReorderAttributes_NestedBlockPathRejectsNonListConfig(t *testing.T) {
+	stub := gostub.Stub(&filesystem.Fs, fakeFs(map[string]string{
+		"/main.tf": `
+terraform {
+  required_providers {}
+}
+`,
+	}))
+	defer stub.Reset()
+
+	mptf := `
+transform "reorder_attributes" this {
+  target_block_address = "terraform"
+  nested_block_path    = "required_providers"
+}
+`
+	readFile, diag := hclsyntax.ParseConfig([]byte(mptf), "test.hcl", hcl.InitialPos)
+	require.Falsef(t, diag.HasErrors(), diag.Error())
+	writeFile, diag := hclwrite.ParseConfig([]byte(mptf), "test.hcl", hcl.InitialPos)
+	require.Falsef(t, diag.HasErrors(), diag.Error())
+	hclBlock := golden.NewHclBlock(readFile.Body.(*hclsyntax.Body).Blocks[0], writeFile.Body().Blocks()[0], nil)
+
+	cfg, err := pkg.NewMetaProgrammingTFConfig(&pkg.TerraformModuleRef{
+		Dir:    "/",
+		AbsDir: "/",
+	}, nil, []*golden.HclBlock{hclBlock}, nil, context.TODO())
+	require.NoError(t, err)
+	_, err = pkg.RunMetaProgrammingTFPlan(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Decode error")
+	assert.Contains(t, err.Error(), "list of string required")
 }
 
 // TestReorderAttributes_CompositionCollision pins the #102 fix:


### PR DESCRIPTION
## Summary
- Add nested_block_path to reorder direct attributes in one unambiguous nested block.
- Sort required_providers entries without changing comments or expressions.
- Document syntax and expand regression coverage.

## Validation
- go test ./pkg -run '^TestReorderAttributes' -count=1
- go test ./...
- go build github.com/Azure/mapotf

Lint could not run because Docker Desktop is unavailable.